### PR TITLE
ci: improve OSSF token permissions security

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -19,7 +19,9 @@ jobs:
     name: Validate Template
     runs-on: ubuntu-latest
     if: github.repository == 'azure/osdu-spi'
-    
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Only run in the template repository
 concurrency:
@@ -18,6 +17,9 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     if: github.repository == 'azure/osdu-spi'
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5


### PR DESCRIPTION
## Summary of Changes

This update modifies GitHub Actions workflow permissions by implementing more granular, job-level permission controls instead of workflow-level permissions.

## Key Modifications

### dev-ci.yml Workflow
- Added explicit `permissions` block to the "Validate Template" job
- Granted `contents: read` permission at the job level
- Ensures the job has minimal necessary permissions for checkout operations

### dev-release.yml Workflow
- Moved `contents: write` and `pull-requests: write` permissions from workflow level to job level
- Set workflow-level permissions to `contents: read` (default restrictive baseline)
- Applied elevated permissions (`contents: write`, `pull-requests: write`) specifically to the "Create Release" job where they are required

## Technical Details

The changes implement the principle of least privilege by:
- Restricting default workflow permissions to read-only access
- Elevating permissions only for specific jobs that require write access
- Maintaining the same functional capabilities while reducing the permission scope for jobs that don't need write access