### PR TITLE
fix: correct GitHub App token action SHA

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7f1f3af0f34c83ac5e6a74fd839
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42  # v2.1.4
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/init-complete.yml
+++ b/.github/workflows/init-complete.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7f1f3af0f34c83ac5e6a74fd839
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42  # v2.1.4
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7f1f3af0f34c83ac5e6a74fd839
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42  # v2.1.4
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Updates the `actions/create-github-app-token` action from commit `5d869da` to `67018539` (version v2.1.4) across multiple GitHub workflow files.

## Key Modifications

### Workflow Files Updated
- `.github/workflows/dev-release.yml` - Updated token generation step in the release job
- `.github/workflows/init-complete.yml` - Updated token generation in both the `init-complete` job and `delete-branch` job

### Technical Details
- **Action Updated**: `actions/create-github-app-token`
- **Previous Commit**: `5d869da34e18e7f1f3af0f34c83ac5e6a74fd839`
- **New Commit**: `67018539274d69449ef7c02e8e71183d1719ab42`
- **Version Tag**: v2.1.4 (now explicitly documented via inline comment)
- All three instances maintain the same configuration parameters:
  - `app-id`: `${{ secrets.RELEASE_APP_ID }}`
  - `private-key`: `${{ secrets.RELEASE_APP_PRIVATE_KEY }}`

### Changes Applied
The update affects three separate job steps that generate GitHub App tokens for authentication purposes during automated release and initialization workflows. The commit hash is now accompanied by a version comment for easier tracking