### PR TITLE
build(ci): upgrade actions/setup-node from v5 to v6

### DIFF
--- a/.github/template-workflows/codeql.yml
+++ b/.github/template-workflows/codeql.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'

--- a/.github/template-workflows/sync.yml
+++ b/.github/template-workflows/sync.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           


### PR DESCRIPTION
## Summary of Changes

This merge request updates the `actions/setup-node` GitHub Action from version 5 to version 6 across two workflow files.

## Key Modifications

### Workflow File Updates

**`.github/template-workflows/codeql.yml`**
- Updated `actions/setup-node` from `v5` to `v6` in the CodeQL analysis workflow
- This action is conditionally executed only when the matrix language is `javascript-typescript`
- Node.js version 18 configuration and npm caching remain unchanged

**`.github/template-workflows/sync.yml`**
- Updated `actions/setup-node` from `v5` to `v6` in the sync workflow
- Node.js version 18 configuration remains unchanged

## Technical Details

Both workflow files maintain their existing Node.js configuration:
- Node.js version: `18`
- Package manager cache: `npm` (in codeql.yml)

The version bump applies to the GitHub Action itself, not the Node.js runtime version used in the workflows