### PR TITLE
fix(scorecard): use approved codeql-action v3.30.6 for workflow verification

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -57,6 +57,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@caa5102941e77fe39b460490c70318beb68c5c25  # v4
+        uses: github/codeql-action/upload-sarif@64d10c13136e1c5bce3e5fbde8d4906eeaafc885  # v3.30.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Bug Fix: OpenSSF Scorecard Workflow Verification Failure

### Problem
The OpenSSF Scorecard workflow was failing with a workflow verification error when publishing results:

```
workflow verification failed: imposter commit: caa5102941e77fe39b460490c70318beb68c5c25 
does not belong to github/codeql-action/upload-sarif
```

### Root Cause
When `publish_results: true` is enabled, the Scorecard action enforces strict workflow verification to maintain API dataset integrity. The codeql-action v4 commit SHA we were using failed this verification check.

### Solution
Downgraded `github/codeql-action/upload-sarif` from v4 to v3.30.6 (commit: 64d10c13136e1c5bce3e5fbde8d4906eeaafc885), which matches the approved version used in the [official OpenSSF Scorecard repository](https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml).

### Testing
- ✅ YAML validation passed
- ⏳ Waiting for workflow run to verify fix

### Related
- Closes issue with scorecard badge activation
- Follows [OpenSSF Scorecard workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)