### PR TITLE
build(ci): bump github/codeql-action from 3.30.6 to 4.30.9

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -57,6 +57,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@64d10c13136e1c5bce3e5fbde8d4906eeaafc885  # v3.30.6
+        uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047  # v4.30.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Updates the CodeQL SARIF upload action to a newer major version in the Scorecard security workflow.

## Key Modifications

### GitHub Actions Version Update
- **Action**: `github/codeql-action/upload-sarif`
- **Previous version**: v3.30.6 (commit `64d10c13136e1c5bce3e5fbde8d4906eeaafc885`)
- **New version**: v4.30.9 (commit `16140ae1a102900babc80a33c44059580f687047`)

## Technical Details

### Major Version Upgrade
- Upgrades from v3 to v4 of the CodeQL action, representing a major version change that may include breaking changes or significant feature updates
- The action is used to upload SARIF (Static Analysis Results Interchange Format) results to GitHub's code scanning feature
- Maintains the same `sarif_file: results.sarif` configuration parameter