### PR TITLE
fix: remove invalid GitHub Advanced Security status check from ruleset

### DIFF
--- a/.github/rulesets/default-branch.json
+++ b/.github/rulesets/default-branch.json
@@ -48,9 +48,6 @@
         "required_status_checks": [
           {
             "context": "CodeQL"
-          },
-          {
-            "context": "GitHub Advanced Security"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Removes the "GitHub Advanced Security" required status check from the default branch ruleset, reducing the number of mandatory checks from two to one.

## Key Modifications

### Branch Protection Changes (`.github/rulesets/default-branch.json`)
- Removed the "GitHub Advanced Security" status check requirement from the `required_status_checks` array
- Retained the "CodeQL" status check as the sole required check
- The ruleset continues to enforce pull request requirements and other branch protection rules

## Technical Details
- The change modifies the branch protection enforcement by eliminating one of the two previously required status checks
- Pull requests targeting the default branch will no longer be blocked if the "GitHub Advanced Security" check fails or is absent
- The "CodeQL" check remains mandatory and must pass before merging

Closes #35