### PR TITLE
chore(config): exclude CODEOWNERS from fork sync

### DIFF
--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -34,10 +34,6 @@
       {
         "path": ".github/security-patterns.txt",
         "description": "Security scanning patterns"
-      },
-      {
-        "path": "CODEOWNERS",
-        "description": "Code ownership and review assignments"
       }
     ],
     "workflows": {
@@ -115,7 +111,8 @@
   },
   "exclusions": [
     ".github/copilot-instructions.md",
-    ".github/local-actions"
+    ".github/local-actions",
+    "CODEOWNERS"
   ],
   "cleanup_rules": {
     "description": "Files and directories to remove during repository initialization",


### PR DESCRIPTION
## Summary of Changes

This change modifies the GitHub sync configuration to adjust how the `CODEOWNERS` file is handled during repository synchronization.

## Key Modifications

### CODEOWNERS File Handling
- **Removed** `CODEOWNERS` from the `shared_files` array (lines 38-41)
  - Previously configured as a shared file with description "Code ownership and review assignments"
  - No longer treated as a file to be synced across repositories

- **Added** `CODEOWNERS` to the `exclusions` array (line 115)
  - Now explicitly excluded from synchronization operations
  - Placed alongside existing exclusions for `.github/copilot-instructions.md` and `.github/local-actions`

## Technical Details

The configuration change moves `CODEOWNERS` from a synchronized shared file to an excluded file, allowing each repository to maintain its own code ownership definitions independently. This prevents the sync process from overwriting repository-specific ownership assignments with a centralized version.