### PR TITLE
fix: add CODEOWNERS to cleanup rules during initialization

### DIFF
--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -148,6 +148,10 @@
         "reason": "Template development changelog - fork instances use upstream changelog"
       },
       {
+        "path": "CODEOWNERS",
+        "reason": "Template-specific code owners - fork instances define their own ownership"
+      },
+      {
         "path": ".github/ISSUE_TEMPLATE/branch-protection-reminder.md",
         "reason": "Template initialization issue template"
       },


### PR DESCRIPTION
## Summary
Updates the sync configuration to exclude the `CODEOWNERS` file from synchronization between template and fork instances.

## Key Modifications

### Sync Configuration Update (`.github/sync-config.json`)
- Added `CODEOWNERS` to the list of excluded paths in the sync configuration
- Positioned after the `CHANGELOG.md` exclusion entry
- Includes explanatory reason: "Template-specific code owners - fork instances define their own ownership"

## Technical Details
- The exclusion prevents the template repository's code ownership rules from overwriting fork-specific ownership configurations
- Allows each fork instance to maintain independent code review and approval workflows through their own `CODEOWNERS` file
- Follows the existing pattern of excluding template-specific files like `CHANGELOG.md` and issue templates