### PR TITLE
chore(ci): update release-please-action to latest version

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -32,7 +32,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Generate Release PR
-        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c  # v4
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary of Changes

Updates the `googleapis/release-please-action` GitHub Action from commit `c2a5a2b` to `16a9c90` within the dev-release workflow.

## Key Modifications

### GitHub Actions Dependency Update
- **File**: `.github/workflows/dev-release.yml`
- **Change**: Updated `googleapis/release-please-action` reference from commit hash `c2a5a2bd6a758a0937f1ddb1e8950609867ed15c` to `16a9c90856f42705d54a6fda1823352bdc62cf38`
- **Version**: Both commits reference v4 of the action
- **Purpose**: Updates the release automation action to a newer commit within the same major version

### Technical Details
- The action is used in the "Generate Release PR" step of the dev-release job
- The action continues to use the GitHub App token generated in the previous step
- Pin-to-commit strategy is maintained for supply chain security, ensuring reproducible builds