### PR TITLE
fix(ci): remove update restriction from default branch ruleset

### DIFF
--- a/.github/rulesets/default-branch.json
+++ b/.github/rulesets/default-branch.json
@@ -14,12 +14,6 @@
       "type": "creation"
     },
     {
-      "type": "update",
-      "parameters": {
-        "update_allows_fetch_and_merge": false
-      }
-    },
-    {
       "type": "deletion"
     },
     {


### PR DESCRIPTION
## Summary of Changes

This change modifies the GitHub repository ruleset configuration for the default branch by removing a branch update restriction rule.

## Key Modifications

### Ruleset Configuration Update
- **Removed rule**: The `update` rule type with parameter `update_allows_fetch_and_merge: false` has been deleted from `.github/rulesets/default-branch.json`
- **Remaining rules**: The ruleset still enforces `creation` and `deletion` restrictions on the default branch

## Technical Details

### Branch Protection Impact
- Previously, the ruleset prevented branch updates that allow fetch-and-merge operations
- With this rule removed, the default branch can now accept updates through fetch-and-merge workflows
- This enables release operations that were previously blocked
