### PR TITLE
fix(ci): resolve dependabot sync conflicts and improve copilot setup resilience

### DIFF
--- a/.github/fork-resources/copilot-setup-steps.yml
+++ b/.github/fork-resources/copilot-setup-steps.yml
@@ -36,6 +36,7 @@ jobs:
           cache: 'maven'
 
       - name: Install Maven dependencies
+        continue-on-error: true
         env:
           # Fix for Maven 3.9+ network issues with Azure/GitHub Actions
           # Limits connection lifetime to prevent stale connections from being reused
@@ -66,6 +67,7 @@ jobs:
           done
 
       - name: Install Trivy security scanner
+        continue-on-error: true
         run: |
           sudo apt-get update
           sudo apt-get install wget apt-transport-https gnupg lsb-release
@@ -75,7 +77,8 @@ jobs:
           sudo apt-get install trivy
 
       - name: Verify Java installation
+        continue-on-error: true
         run: |
           java -version
           mvn -version
-          trivy version
+          trivy version || echo "⚠️ Trivy not available (installation may have failed)"

--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -16,11 +16,7 @@
     ],
     "files": [
       {
-        "path": ".github/dependabot.yml",
-        "description": "Dependency update configuration"
-      },
-      {
-        "path": ".github/labels.json", 
+        "path": ".github/labels.json",
         "description": "Repository label definitions"
       },
       {


### PR DESCRIPTION
## Summary of Changes

This merge request modifies GitHub Actions workflow configuration and repository sync settings to improve workflow resilience and adjust file synchronization scope.

## Key Modifications

### Workflow Error Handling (.github/fork-resources/copilot-setup-steps.yml)

- Added `continue-on-error: true` to three critical setup steps:
  - "Install Maven dependencies" step
  - "Install Trivy security scanner" step
  - "Verify Java installation" step

- Modified the Trivy version verification command to include a fallback message:
  - Changed from `trivy version` to `trivy version || echo "⚠️ Trivy not available (installation may have failed)"`
  - This provides explicit feedback when Trivy installation fails rather than silently continuing

### Sync Configuration (.github/sync-config.json)

- Removed `.github/dependabot.yml` from the synchronized files list
  - This file will no longer be automatically synced across repositories
  - The "Dependency update configuration" entry has been eliminated

- Cleaned up formatting: removed trailing whitespace from the `.github/labels.json` entry

## Technical Details

The `continue-on-error: true` directive allows the workflow to proceed even if these steps fail, preventing complete workflow failure due to:
- Maven dependency resolution issues
- Trivy installation problems (apt repository access, package availability)
- Java/Maven/Trivy verification failures

The Trivy verification now uses shell OR operator (`||`) to display a warning message instead of failing silently, improving observability of installation issues while maintaining workflow continuity