### PR TITLE
chore(deps): separate dependabot concerns between template and forks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,26 @@
 version: 2
 updates:
-  # GitHub Actions - Template Development Workflows
-  # Monitor workflows in .github/workflows/ (template repository workflows)
+  # ========================================================================
+  # TEMPLATE REPOSITORY CONFIGURATION
+  # ========================================================================
+  # This configuration is for the TEMPLATE repository (azure/osdu-spi)
+  # which serves as the engineering system/platform.
+  #
+  # ARCHITECTURE DECISION:
+  # - Template owns: Engineering system (.github workflows and actions)
+  # - Forks own: Application code (Maven dependencies)
+  # - Updates flow: Template → sync-template → Forks
+  #
+  # Fork repositories receive .github updates via sync-template workflow,
+  # NOT via their own dependabot. This eliminates race conditions and
+  # duplicate PRs while maintaining clear separation of concerns.
+  # ========================================================================
+
+  # GitHub Actions - Engineering System (Template Responsibility)
+  # Monitors ALL .github subdirectories recursively for workflow/action updates
+  # Includes: workflows/, template-workflows/, actions/, local-actions/
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github"
     schedule:
       interval: "daily"
       time: "08:00"
@@ -19,65 +36,8 @@ updates:
           - "patch"
     open-pull-requests-limit: 5
 
-  # GitHub Actions - Fork Production Workflows
-  # Monitor workflows in .github/template-workflows/ (copied to forks during init)
-  - package-ecosystem: "github-actions"
-    directory: "/.github/template-workflows"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    target-branch: "main"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
-
-  # GitHub Actions - Composite Actions
-  # Monitor composite actions in .github/actions/ (used by workflows)
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    target-branch: "main"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
-
-  # GitHub Actions - Local Initialization Actions
-  # Monitor template-only actions used during fork initialization
-  - package-ecosystem: "github-actions"
-    directory: "/.github/local-actions"
-    schedule:
-      interval: "daily"
-      time: "08:00"
-    target-branch: "main"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
-
-  # Python - Documentation Dependencies
-  # Monitor MkDocs and related documentation tooling
+  # Python - Documentation Dependencies (Template Responsibility)
+  # Monitor MkDocs and related documentation tooling for the template
   - package-ecosystem: "pip"
     directory: "/doc"
     schedule:

--- a/.github/fork-resources/dependabot.yml
+++ b/.github/fork-resources/dependabot.yml
@@ -1,57 +1,7 @@
 version: 2
 updates:
-  # GitHub Actions - Fork Workflows
-  # Monitor all GitHub Actions for security updates
-  # Aligns with ADR-026: Dependabot Security Update Strategy
-  #
-  # Schedule Strategy:
-  # - Fork repos: Weekly (Monday 08:00 UTC)
-  # - Template repo: Daily (08:00 UTC)
-  # - Template sync: Daily propagation
-  # This design ensures forks receive updates via template sync before
-  # their own dependabot finds them, reducing duplicate PRs
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-    target-branch: "main"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
-
-  # GitHub Actions - Composite Actions
-  # Monitor composite actions synced from template repository
-  #
-  # Note: These actions are synced from the template, but fork monitoring
-  # provides a backup check and independent validation. This redundancy
-  # ensures critical security patches are caught even if sync-template
-  # has delays or issues.
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-    target-branch: "main"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 5
+  # Maven Dependencies - Application Code
+  # Workflow and GitHub Actions updates are managed via template synchronization
 
   # 1) TOP-LEVEL AGGREGATOR
   #    Scans the root POM, but ignores any dependencies physically declared in


### PR DESCRIPTION
## Summary

This change restructures the Dependabot configuration to implement a **Separation of Concerns** architecture between the template repository and its forks, eliminating duplicate PRs and race conditions during fork initialization.

## Key Modifications

### Template Repository Configuration (`.github/dependabot.yml`)

- **Consolidated GitHub Actions monitoring**: Reduced from 4 separate directory configurations to a single `/.github` directory monitor that recursively scans all subdirectories (workflows, template-workflows, actions, local-actions)
- **Removed 40 lines of redundant configuration**: Eliminated separate monitoring blocks for `.github/workflows/`, `.github/template-workflows/`, `.github/actions/`, and `.github/local-actions/`
- **Retained Python/pip monitoring**: Kept documentation dependencies (`/doc`) under template responsibility
- **Added architectural documentation**: Inline comments explain the template owns engineering system updates, forks own application code

### Fork Repository Configuration (`.github/fork-resources/dependabot.yml`)

- **Removed all GitHub Actions monitoring**: Deleted 2 separate GitHub Actions configuration blocks (57 lines total) that monitored `/` and `/.github/actions`
- **Eliminated weekly schedule for workflows**: Removed `interval: "weekly"` configuration that created race conditions with template sync
- **Retained Maven dependency monitoring**: Kept all Maven configurations for root POM, service-core, and provider modules unchanged
- **Updated comments**: Clarified that workflow updates come via template synchronization, not fork Dependabot

### Architecture Documentation (ADR-026)

- **Updated status**: Added "Updated - 2025-10-24 (Separation of Concerns Architecture)" to status section
- **Expanded context**: Added point #6 about engineering system updates being maintained separately
- **Revised decision section**: Changed from "Controlled Dependabot Strategy" to "Separation of Concerns Dependabot Strategy" with 6 points instead of 5
- **Added update flow diagram**: New section showing day-by-day flow of updates from template (Day 1 08:00) through sync-template (Day 2 08:00) to forks (Sunday 09:00)
- **Restructured update groups table**: Changed from frequency-based grouping to repository/ecosystem-based grouping showing clear ownership
- **Updated consequences**: Added 4 new positive consequences (eliminated race conditions, no duplicate PRs, clear separation, scalable architecture) and 1 new negative consequence (template dependency)

## Technical Details

### Recursive Directory Monitoring

The template now uses `directory: "/.github"` which monitors all subdirectories recursively, replacing the previous approach of explicitly listing each subdirectory. This simplifies maintenance when new action or workflow directories are added.

### Update Timing Strategy

- **Template**: Daily scans at 08:00 UTC for immediate security response
- **Forks**: Weekly scans on Sunday at 09:00 UTC, after template sync has propagated changes
- **Sync propagation**: Template changes flow to forks via `sync-template` workflow on Day 2, before fork Dependabot runs on Sunday

### Eliminated Configuration Duplication

Previously, both template and forks monitored GitHub Actions in overlapping directories, creating scenarios where:
1. Template Dependabot creates PR for `actions/checkout@v4 → v5`
2. Fork Dependabot independently finds same update
3. Both PRs compete during fork initialization

The new architecture ensures template is the single source of truth for `.github` updates.