### PR TITLE
ci: use GitHub App token for release-please to trigger workflows

### DIFF
--- a/.github/template-workflows/release.yml
+++ b/.github/template-workflows/release.yml
@@ -43,13 +43,20 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      
+
     steps:
+      - name: "Generate GitHub App Token"
+        id: app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42  # v2.1.4
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: "Generate Release PR"
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           
   tag-with-upstream:


### PR DESCRIPTION
## Summary
This change modifies the GitHub Actions release workflow to use a GitHub App token instead of the default `GITHUB_TOKEN` for authentication with the release-please action.

## Key Modifications

### GitHub App Token Generation
- Added a new step `Generate GitHub App Token` that creates a token using the `actions/create-github-app-token` action (v2.1.4, pinned to commit `67018539274d69449ef7c02e8e71183d1719ab42`)
- The token generation requires two secrets: `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`
- The generated token is stored in the step output as `app-token.outputs.token`

### Release Please Action Update
- Modified the `Generate Release PR` step to use the GitHub App token (`${{ steps.app-token.outputs.token }}`) instead of the default `GITHUB_TOKEN`
- This change affects how the `googleapis/release-please-action@v4` authenticates when creating release pull requests

## Technical Details
- The GitHub App token action is pinned to a specific commit hash for security and reproducibility
- The workflow maintains the same permissions structure (`contents: write`, `pull-requests: write`, `issues: write`)
- Minor whitespace cleanup: removed trailing spaces on line 46