### PR TITLE
fix(ci): add GITHUB_TOKEN to validate workflow and exclude release-please PRs

### DIFF
--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: "Validate Commit Messages"
         if: |
-          needs.check-repo-state.outputs.is_initialized == 'true' && 
+          needs.check-repo-state.outputs.is_initialized == 'true' &&
           github.actor != 'dependabot[bot]' &&
           github.actor != 'copilot' &&
           !contains(github.actor, 'copilot') &&
@@ -244,8 +244,11 @@ jobs:
           !startsWith(github.event.pull_request.title, 'chore(sync)') &&
           !startsWith(github.event.pull_request.title, '⬆️ Sync with upstream') &&
           !startsWith(github.event.pull_request.title, '🚀 Production Release: Upstream Integration') &&
-          !startsWith(github.head_ref, 'release/upstream-')
+          !startsWith(github.head_ref, 'release/upstream-') &&
+          !startsWith(github.head_ref, 'release-please--branches--')
         uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             feat


### PR DESCRIPTION
## Problem

After syncing template updates to fork repositories, the validate workflow fails on release-please PRs with the error:
```
##[error]Parameter token or opts.auth is required
```

**Example failure**: https://github.com/danielscholl-osdu/partition/actions/runs/19339779845

## Root Cause

The `amannn/action-semantic-pull-request@v6` action requires explicit `GITHUB_TOKEN` when running on `pull_request_target` events, but it wasn't being provided.

Additionally, release-please PRs (automated release PRs on branches like `release-please--branches--main`) were not excluded from commit message validation.

## Changes

1. **Added GITHUB_TOKEN environment variable** to the "Validate Commit Messages" step
   - Provides authentication for the semantic PR action
   - Required for `pull_request_target` event trigger

2. **Excluded release-please PRs** from validation
   - Added condition: `!startsWith(github.head_ref, 'release-please--branches--')`
   - Release-please PRs are automated and don't need commit message validation

## Testing

- Template sync will propagate this fix to fork repositories
- Release-please PRs will be excluded from validation
- Other PRs will continue to be validated with proper authentication

## Related

- Discovered after merging PR #54 and syncing to fork repository
- Fixes validation failures on release-please PRs like danielscholl-osdu/partition#8