### PR TITLE
fix(validate): skip java-build for sync PRs targeting fork_upstream

### DIFF
--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -171,11 +171,16 @@ jobs:
   java-build:
     name: "🔨 Java Build"
     needs: [check-initialization, check-repo-state]
-    # Modified condition to exclude Dependabot PRs
+    # Skip java-build for:
+    # - Dependabot PRs (handled by dependabot-validation.yml)
+    # - Sync PRs targeting fork_upstream (per ADR-028: local actions don't exist on sync branches
+    #   because they contain only upstream content; build validation occurs during cascade to
+    #   fork_integration where .github/actions/ exists)
     if: |
-      needs.check-repo-state.outputs.is_initialized == 'true' && 
+      needs.check-repo-state.outputs.is_initialized == 'true' &&
       needs.check-repo-state.outputs.is_java_repo == 'true' &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      !(github.event.pull_request.base.ref == 'fork_upstream' && startsWith(github.event.pull_request.head.ref, 'sync/'))
     runs-on: ubuntu-latest
     outputs:
       is_java_project: ${{ steps.build.outputs.is_java_project }}
@@ -313,6 +318,9 @@ jobs:
           # Handle Dependabot PRs differently
           if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
             ITEMS=$(echo "$ITEMS" | jq '. + ["ℹ️ Dependabot Build Handled by dependabot-validation.yml"]')
+          # Handle sync PRs targeting fork_upstream (build deferred to cascade)
+          elif [[ "${{ github.event.pull_request.base.ref }}" == "fork_upstream" ]] && [[ "${{ github.event.pull_request.head.ref }}" == sync/* ]]; then
+            ITEMS=$(echo "$ITEMS" | jq '. + ["ℹ️ Sync PR: Build validation deferred to cascade integration"]')
           # For non-Dependabot PRs, report build status
           elif [[ "${{ needs.check-repo-state.outputs.is_initialized }}" == "true" ]]; then
             if [[ "${{ needs.check-repo-state.outputs.is_java_repo }}" == "true" ]]; then


### PR DESCRIPTION
## Summary

Fixes validation workflow failures for upstream sync PRs by skipping the `java-build` job when PRs from `sync/*` branches target `fork_upstream`.

### Problem

When the sync workflow creates PRs from `sync/upstream-*` branches to `fork_upstream`, the validation workflow's `java-build` job fails with:
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.github/actions/java-build'
```

This occurs because:
1. Sync branches contain only upstream content (from OSDU GitLab)
2. Upstream repos don't have our custom `.github/actions/` directory
3. The `pull_request_target` trigger checks out the PR head (sync branch)
4. Local action references (`uses: ./.github/actions/java-build`) resolve to the checked-out code

### Root Cause Analysis

Per ADR-028 Section 7.1, this constraint is documented for `sync.yml`:
> **Constraint**: sync.yml runs from `fork_upstream` branch where `.github/actions/` don't exist

The same constraint applies to `validate.yml` when it checks out sync branch content via `pull_request_target`.

### Solution

Skip the `java-build` job for sync PRs targeting `fork_upstream`. Build validation will occur during the cascade phase when changes flow to `fork_integration`, which has the full `.github/actions/` infrastructure.

### Changes

- Added condition to skip `java-build` for PRs where `base.ref == 'fork_upstream'` and `head.ref` starts with `sync/`
- Added informational status message for sync PRs indicating build validation is deferred to cascade integration
- Added comments referencing ADR-028 for future maintainers

## Test Plan

- [ ] Verify existing PRs to `main` still trigger java-build
- [ ] Verify sync PRs to `fork_upstream` skip java-build without failure
- [ ] Verify status report shows appropriate message for sync PRs