### PR TITLE
chore(dependabot): exclude non-Azure providers from dependency scanning

### DIFF
--- a/.github/fork-resources/dependabot.yml
+++ b/.github/fork-resources/dependabot.yml
@@ -16,6 +16,16 @@ updates:
     labels:
       - "dependencies"
       - "common"
+    exclude-paths:
+      # Exclude non-Azure cloud providers
+      - "provider/*-aws/**"
+      - "provider/*-gcp/**"
+      - "provider/*-gc/**"
+      - "provider/*-ibm/**"
+      - "provider/*-jdbc/**"
+      # Exclude test directories
+      - "testing/**"
+      - "*-acceptance-test/**"
     groups:
       spring:
         patterns:


### PR DESCRIPTION
- Concise summary of changes:
  - Updated Dependabot configuration to exclude certain paths from dependency updates, specifically non-Azure cloud provider folders and test directories.

- Key modifications and their purpose:
  - Added exclude-paths under the updates section to skip:
    - provider/*-aws/**
    - provider/*-gcp/**
    - provider/*-gc/**
    - provider/*-ibm/**
    - provider/*-jdbc/**
  - Added:
    - testing/**
    - *-acceptance-test/**
  - Purpose: Reduce noise by avoiding dependency scans/updates for unused or external provider code and test directories, focusing updates on relevant Azure-related components.

- Notable technical details:
  - File modified: .github/fork-resources/dependabot.yml
  - Placement: within the existing updates: labels and groups structure, now extending with exclude-paths to filter which paths Dependabot scans.

- Security impact analysis:
  - No vulnerability data provided in this diff; the change does not fix or introduce CVEs.
  - This is a scope refinement for Dependabot updates, potentially reducing the surface area of automated dependency updates and focusing updates on relevant code paths.