### PR TITLE
chore(dependabot): use directories globs to exclude non-Azure providers

### DIFF
--- a/.github/fork-resources/dependabot.yml
+++ b/.github/fork-resources/dependabot.yml
@@ -2,12 +2,18 @@ version: 2
 updates:
   # Maven Dependencies - Application Code
   # Workflow and GitHub Actions updates are managed via template synchronization
+  #
+  # IMPORTANT: This config explicitly lists directories to scan using globs.
+  # Non-Azure providers (AWS, GCP, IBM, JDBC) are intentionally excluded by
+  # NOT including their paths. Only Azure-related modules are monitored.
 
-  # 1) TOP-LEVEL AGGREGATOR
-  #    Scans the root POM, but ignores any dependencies physically declared in
-  #    testing/**, <service>-acceptance-test/**, etc.
+  # 1) COMMON MODULES
+  #    Root pom.xml and service core modules (excludes all provider directories)
   - package-ecosystem: "maven"
-    directory: "/"
+    directories:
+      - "/"              # Root pom.xml only
+      - "/*-core"        # Service core modules (e.g., <service>-core)
+      - "/*-core-plus"   # Service core-plus modules
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -16,6 +22,9 @@ updates:
     labels:
       - "dependencies"
       - "common"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       spring:
         patterns:
@@ -67,34 +76,16 @@ updates:
           - "minor"
           - "patch"
 
-  # 2) <service> CORE
+  # 2) AZURE PROVIDER
+  #    Only Azure provider modules - explicitly excludes AWS, GCP, IBM, JDBC
   - package-ecosystem: "maven"
-    directory: "/<service>-core"
+    directories:
+      - "/provider/*-azure"    # Only Azure providers (e.g., provider/<service>-azure)
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "09:00"
-    labels:
-      - "dependencies"
-      - "common"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      core-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # 3) SPI AZURE
-  - package-ecosystem: "maven"
-    directory: "/provider/<service>-azure"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
+    target-branch: "main"
     labels:
       - "dependencies"
       - "azure"
@@ -107,6 +98,6 @@ updates:
           - "minor"
           - "patch"
 
-  # Note: Disabled providers/modules omitted to avoid validation errors
-  # Dependabot does not support 'interval: never'
-  # If you need to disable updates for specific modules, simply remove them from this file
+  # Note: Non-Azure providers (AWS, GCP, IBM, JDBC) are intentionally NOT listed.
+  # By using explicit 'directories' with globs, only the specified paths are scanned.
+  # This prevents Dependabot from creating PRs for cloud providers we don't maintain.


### PR DESCRIPTION
- Summary of changes:
  - Reworked the Dependabot configuration to narrow scanning scope to core modules and Azure provider modules, replacing the previous multi-tier structure.
  - Added an ignore rule to skip semver-major dependency updates globally.
  - Adjusted the Azure provider scanning to use a broader glob (/provider/*-azure) and set the update target to the main branch.
  - Included clarifying comments to explain the scanning behavior and provider exclusions.

- Key modifications and their purpose:
  - Replace top-level and per-service core sections with a COMMON MODULES approach:
    - Directories now include root, and core/core-plus modules (e.g., "/*-core", "/*-core-plus"), reducing Dependabot scope to essential modules only.
    - Purpose: minimize scan surface area to maintainable modules while excluding provider-specific directories.
  - Global ignore for semver-major updates:
    - ignore: dependency-name: "*" with update-types: ["version-update:semver-major"]
    - Purpose: avoid automatic PRs for major version bumps, reducing noise; ensures only non-breaking or minor/patch updates are proposed automatically.
  - Azure provider updates scoped to Azure modules only:
    - directories: ["/provider/*-azure"] and added target-branch: "main"
    - Purpose: restrict updates to known Azure provider modules and align PR targets with the main branch.
  - Expanded inline guidance:
    - Added comments explaining that non-Azure providers are intentionally not listed and that explicit directory globs control scanning scope.

- Notable technical details:
  - Use of directories with wildcards instead of plain directory paths (e.g., "/*-core", "/*-core-plus", "/provider/*-azure").
  - Schedule remains weekly on Sunday; azure updates now specify target-branch: main.
  - Comments clarify scanning strategy and provider exclusions for future maintainers.

- Security impact analysis:
  - No vulnerability data is introduced or addressed in this change.
  - Scanning scope is narrowed to reduce exposure to third-party dependencies outside maintained modules, which lowers the surface area for dependency update PRs.
  - However, ignoring semver-major updates may delay critical security fixes that are shipped in major bumps; be aware of the potential risk of missing important vulnerabilities tied to major version upgrades.
  - Azure provider updates are now the explicit focus, tightening control over which dependencies are automatically proposed for review.

Non-Azure providers intentionally NOT listed. By using explicit 'directories' with globs, only the specified paths are scanned.