### PR TITLE
chore(dependabot): add exclude-paths to skip non-Azure providers

### DIFF
--- a/.github/fork-resources/dependabot.yml
+++ b/.github/fork-resources/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   # Workflow and GitHub Actions updates are managed via template synchronization
 
   # 1) TOP-LEVEL AGGREGATOR
-  #    Scans the root POM, but ignores any dependencies physically declared in
-  #    testing/**, <service>-acceptance-test/**, etc.
+  #    Scans the root POM and common modules, excluding non-Azure providers
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -16,6 +15,14 @@ updates:
     labels:
       - "dependencies"
       - "common"
+    exclude-paths:
+      - "provider/*-aws/**"
+      - "provider/*-gcp/**"
+      - "provider/*-gc/**"
+      - "provider/*-ibm/**"
+      - "provider/*-jdbc/**"
+      - "testing/**"
+      - "*-acceptance-test/**"
     groups:
       spring:
         patterns:


### PR DESCRIPTION
- Concise summary:
  - Updated the Dependabot configuration to broaden the scan scope to the root POM and common modules, while excluding non-Azure provider directories and test-related paths from automatic dependency updates.

- Key modifications and their purpose:
  - Comment update: from "Scans the root POM, but ignores any dependencies physically declared in testing/**, <service>-acceptance-test/**, etc." to "Scans the root POM and common modules, excluding non-Azure providers" to reflect the new scanning scope.
  - Added exclude-paths block to Dependabot config with patterns to skip updates for:
    - provider/*-aws/**
    - provider/*-gcp/**
    - provider/*-gc/**
    - provider/*-ibm/**
    - provider/*-jdbc/**
    - testing/**
    - *-acceptance-test/**
  Purpose: to limit Dependabot updates to Azure-related modules and common code, reducing noise and focusing on relevant dependency updates.

- Notable technical details:
  - The exclude-paths section is a new configuration block under dependabot.yml, using glob-style patterns to specify directories and file groups to exclude from update scans.
  - The focus remains on maven dependencies in the root directory, but with explicit exclusions to avoid pulling in provider-specific or test-related updates.

- Security impact analysis:
  - Potential positives:
    - Reduces exposure to updates for non-Azure provider dependencies and test code, potentially lowering the risk surface from unrelated third-party updates.
    - Ensures Dependabot PRs concentrate on Azure-related modules, aligning update activity with the intended security focus.
  - Potential negatives:
    - Vulnerabilities in the excluded provider modules (aws, gcp, gc, ibm, jdbc) will not be surfaced or auto-updated by Dependabot, which could leave known issues unaddressed unless monitored separately.
    - Excluding testing and acceptance-test paths might delay updates that fix vulnerabilities introduced in test-related dependencies.
  - Overall: security updates will be more targeted, but require additional processes to monitor or re-include excluded paths if critical vulnerabilities arise.

- Last specific change discussed:
  - Added exclude-paths entry for *-acceptance-test/**.