### PR TITLE
ci(validate): enable sync PR validation by restoring local actions

### DIFF
--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -193,14 +193,21 @@ jobs:
           github.event.pull_request.base.ref == 'fork_upstream' &&
           startsWith(github.event.pull_request.head.ref, 'sync/')
         run: |
+          set -euo pipefail
           # Sync branches contain only upstream content and don't have local actions.
           # Restore .github/actions/ from main branch to enable validation.
           # This also provides security hardening - we always use trusted actions for validation.
           echo "🔧 Restoring local actions from main branch for sync PR validation..."
-          git fetch origin main --depth=1
-          git checkout origin/main -- .github/actions/
+          if ! git fetch origin main --depth=1; then
+            echo "❌ Failed to fetch 'main' branch from origin. Cannot restore local actions."
+            exit 1
+          fi
+          if ! git checkout origin/main -- .github/actions/; then
+            echo "❌ Failed to restore .github/actions/ from origin/main. Cannot proceed with validation."
+            exit 1
+          fi
           echo "✅ Local actions restored - validation can proceed"
-      
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -253,11 +260,19 @@ jobs:
           github.event.pull_request.base.ref == 'fork_upstream' &&
           startsWith(github.event.pull_request.head.ref, 'sync/')
         run: |
+          set -euo pipefail
           # Sync branches contain only upstream content and don't have local actions.
           # Restore .github/actions/ from main branch to enable validation.
+          # This also provides security hardening - we always use trusted actions for validation.
           echo "🔧 Restoring local actions from main branch for sync PR validation..."
-          git fetch origin main --depth=1
-          git checkout origin/main -- .github/actions/
+          if ! git fetch origin main --depth=1; then
+            echo "❌ Failed to fetch 'main' branch from origin. Cannot restore local actions."
+            exit 1
+          fi
+          if ! git checkout origin/main -- .github/actions/; then
+            echo "❌ Failed to restore .github/actions/ from origin/main. Cannot proceed with validation."
+            exit 1
+          fi
           echo "✅ Local actions restored - validation can proceed"
 
       - name: "Validate Commit Messages"


### PR DESCRIPTION
## Summary

Fixes sync PR validation failures caused by missing local actions after switching to GitHub App authentication.

## Problem

After commit `29dba85` switched `sync.yml` from `GITHUB_TOKEN` to GitHub App token, `pull_request_target` events started triggering on sync PRs. The validation workflow checks out the PR head (sync branch), which contains only upstream content and lacks `.github/actions/`.

**Error observed:**
```
Can't find 'action.yml' under '.github/actions/pr-status'
```

**Timeline:**
1. **Before Dec 15**: Sync PRs created with `GITHUB_TOKEN` → validate.yml never triggered (GitHub's anti-recursion protection)
2. **Dec 15 (29dba85)**: Switched to GitHub App token → validate.yml now triggers on sync PRs
3. **Dec 17 (fb62224)**: Added skip for `java-build` → but missed `pr-status` step
4. **Now**: `pr-status` still fails because local actions don't exist on sync branch

## Solution

Instead of skipping validation (which contradicts ADR-009's "comprehensive validation at first integration point"), we now **restore local actions from `main`** after checkout:

```yaml
- name: "Restore local actions for sync PRs"
  if: |
    github.event_name == 'pull_request_target' &&
    github.event.pull_request.base.ref == 'fork_upstream' &&
    startsWith(github.event.pull_request.head.ref, 'sync/')
  run: |
    git fetch origin main --depth=1
    git checkout origin/main -- .github/actions/
```

This gives us:
- **Upstream code to validate** ← from PR head (sync branch)
- **Trusted validation tools** ← from main branch

## Changes

| Component | Before | After |
|-----------|--------|-------|
| `java-build` job | Skipped for sync PRs | ✅ Runs with restored actions |
| `code-validation` job | `pr-status` failed | ✅ Runs with restored actions |
| Validation Report | "Deferred to cascade" | ✅ Reports actual build status |

## Testing

- Triggered fresh sync workflow
- Validation workflow completed successfully
- All jobs passed: Java Build ✅, Code Quality Checks ✅


## Security

This change provides security hardening for `pull_request_target` events:
- Always uses trusted actions from `main` for validation
- Prevents potential malicious actions from external PRs being executed
- Condition is surgically targeted to only affect sync PRs

## Related

- ADR-009: Asymmetric Cascade Review Strategy (comprehensive validation at first integration point)
- ADR-029: GitHub App Authentication Strategy
- Commit `29dba85`: Switch to GitHub App token for sync workflow
- Commit `fb62224`: Partial fix that skipped java-build but missed pr-status