### PR TITLE
fix(ci): remove bare expression syntax from cascade workflow comments

### DIFF
--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -372,7 +372,7 @@ jobs:
             echo "❌ Validation checks failed"
             echo "success=false" >> $GITHUB_OUTPUT
             # Write build output and validation details to files instead of step outputs.
-            # IMPORTANT: Do NOT pass these through step outputs + ${{ }} substitution,
+            # IMPORTANT: Do NOT pass these through step outputs and expression substitution,
             # because literal string substitution of build logs containing parentheses,
             # quotes, and other special characters will break shell parsing.
             echo "$BUILD_OUTPUT" > /tmp/build_output.txt
@@ -387,7 +387,7 @@ jobs:
           echo "🚨 Creating validation failure issue..."
 
           # Read validation details and build output from files written by validate step.
-          # IMPORTANT: These are passed via files (not step outputs) because ${{ }} literal
+          # IMPORTANT: These are passed via files (not step outputs) because expression
           # substitution of build logs breaks shell parsing when they contain parentheses,
           # quotes, backticks, or other special characters.
           VALIDATION_DETAILS=""


### PR DESCRIPTION
## Summary of Changes

This merge request updates documentation comments in the GitHub Actions workflow file to improve clarity around expression substitution syntax.

## Key Modifications

### Documentation Clarification in `.github/template-workflows/cascade.yml`

**Lines 375 and 390**: Updated inline comments explaining why build output and validation details are passed through files rather than step outputs

- **Before**: Referenced `${{ }}` substitution
- **After**: Changed to "expression substitution" terminology

The comments now read:
- Line 375: "Do NOT pass these through step outputs and expression substitution"
- Line 390: "These are passed via files (not step outputs) because expression substitution"

## Technical Details

These changes affect documentation only and do not modify any functional code. The updates standardize the terminology used to describe GitHub Actions expression syntax, replacing the literal `${{ }}` notation with the more general term "expression substitution" while maintaining the same technical warning about shell parsing issues with special characters in build logs