### PR TITLE
fix(ci): upgrade Trivy to v0.69.3 after upstream security incident

### DIFF
--- a/.github/template-workflows/sync.yml
+++ b/.github/template-workflows/sync.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           # Install Trivy
           echo "Installing Trivy..."
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.69.3/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
           
           # Install dependencies if needed
           echo "Dependencies installed"


### PR DESCRIPTION
## Summary

Upgrades Trivy from v0.49.1 to v0.69.3 in the sync workflow template to restore upstream sync functionality across all downstream fork repos.

## Context

On March 1, 2026, the [aquasecurity/trivy](https://github.com/aquasecurity/trivy) repository was compromised via a GitHub Actions `pull_request_target` exploitation. An attacker stole a PAT token and used it to mass-delete GitHub releases **v0.27.0 through v0.69.1**. The deleted release binaries are unrecoverable.

Our sync workflows pin Trivy v0.49.1, which falls in the deleted range — the install script finds the tag but cannot download the binary, causing all upstream syncs to fail.

References:
- [Trivy security incident discussion](https://github.com/aquasecurity/trivy/discussions/10265)
- [StepSecurity analysis of the attack](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation)

## Change

- **File**: `.github/template-workflows/sync.yml`
- **Change**: `v0.49.1` → `v0.69.3` (latest stable release)

## Affected Downstream Repos

Once merged and propagated via `sync-template`, this unblocks daily upstream sync for:
entitlements, file, indexer, indexer-queue, legal, partition, schema, search, storage, workflow