### PR TITLE
fix: resolve date rendering in sync template PR title

### DIFF
--- a/.github/template-workflows/sync-template.yml
+++ b/.github/template-workflows/sync-template.yml
@@ -478,6 +478,10 @@ jobs:
           # Also create a simple version for backwards compatibility
           echo "FALLBACK_DESCRIPTION=Template sync PR - see commit details for changes" >> $GITHUB_ENV
 
+      - name: Set current date
+        if: steps.check-updates.outputs.has_updates == 'true' && env.has_changes == 'true'
+        run: echo "CURRENT_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
       - name: Create new template sync PR
         if: steps.check-updates.outputs.has_updates == 'true' && env.has_changes == 'true' && steps.detect-existing.outputs.has_existing_pr == 'false'
         id: create-pr
@@ -486,7 +490,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           base-branch: main
           head-branch: ${{ env.SYNC_BRANCH }}
-          pr-title: "🔄 Sync template updates $(date +%Y-%m-%d)"
+          pr-title: "Sync template updates ${{ env.CURRENT_DATE }}"
           fallback-description: ${{ env.FALLBACK_DESCRIPTION }}
           fallback-description-b64: ${{ env.FALLBACK_DESCRIPTION_B64 }}
           azure-api-key: ${{ secrets.AZURE_API_KEY }}


### PR DESCRIPTION
## Summary
This change modifies the template sync workflow to improve the reliability of PR title generation by pre-calculating the current date in a separate step rather than inline command substitution.

## Key Modifications

### Date Calculation Refactoring
- **New Step Added**: `Set current date` step now calculates the date using `date +%Y-%m-%d` and stores it in the `CURRENT_DATE` environment variable
- **Conditional Execution**: The new step runs only when `has_updates == 'true'` and `has_changes == 'true'`, matching the conditions of the PR creation step
- **PR Title Update**: Changed from inline command substitution `"🔄 Sync template updates $(date +%Y-%m-%d)"` to environment variable reference `"Sync template updates ${{ env.CURRENT_DATE }}"`

### Technical Details
- The emoji prefix (🔄) has been removed from the PR title
- The date format remains unchanged (YYYY-MM-DD)
- By moving date calculation to a dedicated step, the workflow avoids potential issues with command substitution in the `pr-title` parameter of the `Create new template sync PR` step
- The environment variable approach ensures the date value is properly evaluated and passed to the PR creation action