### PR TITLE
fix(ci): add missing GH_TOKEN to cascade merge step

### DIFF
--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -224,6 +224,8 @@ jobs:
       - name: Merge upstream into fork_integration
         id: merge_upstream
         if: steps.check_state.outputs.integration_in_process == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Merge fork_upstream into fork_integration
           echo "Merging upstream changes into fork_integration..."

--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -66,6 +66,18 @@ jobs:
               echo "::notice::fork_integration is $INTEGRATION_COMMITS commits ahead of main with no active release PRs or conflicts"
               echo "::notice::Checking if this is a stale divergence that can be auto-healed..."
 
+              # Check if fork_upstream is already merged into fork_integration.
+              # If it is, this divergence is from a legitimate merge (possibly with
+              # manually resolved conflicts) — not stale. Skip the reset and let
+              # the cascade proceed to create the release PR.
+              UPSTREAM_IN_INTEGRATION=$(git rev-list --count origin/fork_integration..origin/fork_upstream 2>/dev/null || echo "999")
+              if [ "$UPSTREAM_IN_INTEGRATION" -eq 0 ]; then
+                echo "::notice::fork_upstream is already merged into fork_integration - this is a legitimate in-progress cascade, not stale divergence"
+                echo "::notice::Skipping self-heal, proceeding to create release PR"
+                echo "integration_in_process=false" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+
               # Check if there are any open PRs from fork_integration to main
               INTEGRATION_PRS=$(gh pr list --base main --head fork_integration --json number 2>/dev/null || echo "[]")
               INTEGRATION_PR_COUNT=$(echo "$INTEGRATION_PRS" | jq length)
@@ -230,7 +242,15 @@ jobs:
           # Merge fork_upstream into fork_integration
           echo "Merging upstream changes into fork_integration..."
           CONFLICTS_FOUND=false
-          
+
+          # Check if fork_upstream is already merged (e.g., manual conflict resolution)
+          UPSTREAM_PENDING=$(git rev-list --count HEAD..origin/fork_upstream 2>/dev/null || echo "999")
+          if [ "$UPSTREAM_PENDING" -eq 0 ]; then
+            echo "✅ fork_upstream is already merged into fork_integration - skipping merge"
+            echo "conflicts=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if git merge origin/fork_upstream --no-edit; then
             echo "✅ Clean merge of upstream changes achieved"
           else


### PR DESCRIPTION
## Summary of Changes

This update enhances the cascade workflow's handling of merge states between `fork_upstream` and `fork_integration` branches by adding duplicate detection logic to prevent unnecessary operations when branches are already synchronized.

## Key Modifications

### Stale Divergence Detection Enhancement

Added a pre-check in the `check_state` job (lines 69-79) that detects when `fork_upstream` is already merged into `fork_integration`:
- Uses `git rev-list --count` to determine if `fork_upstream` has any commits not in `fork_integration`
- When count equals 0, the divergence is recognized as legitimate (from a previous merge with manual conflict resolution)
- Sets `integration_in_process=false` and exits early to skip self-healing logic
- Allows the workflow to proceed directly to release PR creation

### Merge Operation Optimization

Added a redundant merge check in the `merge_upstream` step (lines 246-252):
- Performs the same `git rev-list --count` check before attempting the merge operation
- Skips the merge entirely if `fork_upstream` is already incorporated into `fork_integration`
- Sets `conflicts=false` output and exits successfully
- Added `GITHUB_TOKEN` environment variable to the step configuration (lines 239-240)

## Technical Details

Both checks use identical logic with error handling:
- Command: `git rev-list --count origin/fork_integration..origin/fork_upstream`
- Fallback value of "999" if the command fails
- Zero-equality test to confirm branches are synchronized

The workflow now distinguishes between:
- **Stale divergence**: `fork_integration` has drifted from `main` without active work
- **Legitimate divergence**: `fork_integration` contains merged upstream changes, possibly with resolved conflicts