### PR TITLE
fix(cascade): enforce merge-commit method on release PRs via auto-merge

### DIFF
--- a/.github/rulesets/default-branch.json
+++ b/.github/rulesets/default-branch.json
@@ -17,9 +17,6 @@
       "type": "deletion"
     },
     {
-      "type": "required_linear_history"
-    },
-    {
       "type": "non_fast_forward"
     },
     {

--- a/.github/scripts/setup-fork-repo.sh
+++ b/.github/scripts/setup-fork-repo.sh
@@ -213,6 +213,24 @@ set_secret "AZURE_API_VERSION" "$AZURE_API_VERSION"
 
 echo ""
 
+# ── Repository settings ────────────────────────────────────────────
+#
+# allow_auto_merge: required for the cascade workflow to arm auto-merge on
+# release PRs. Without this, the workflow falls back to requiring humans to
+# manually click "Create a merge commit" on each release PR — which is the
+# foot-gun that caused the squash-merge cascade incident on osdu-spi-partition.
+
+echo "==> Configuring repository settings..."
+
+if $DRY_RUN; then
+  echo "    [DRY RUN] Would enable allow_auto_merge=true on $REPO"
+else
+  gh api --method PATCH "repos/$REPO" -F allow_auto_merge=true >/dev/null
+  echo "    Enabled allow_auto_merge"
+fi
+
+echo ""
+
 # ── Summary ────────────────────────────────────────────────────────
 
 if [ "$DRY_RUN" = true ]; then

--- a/.github/scripts/setup-fork-repo.sh
+++ b/.github/scripts/setup-fork-repo.sh
@@ -219,14 +219,21 @@ echo ""
 # release PRs. Without this, the workflow falls back to requiring humans to
 # manually click "Create a merge commit" on each release PR — which is the
 # foot-gun that caused the squash-merge cascade incident on osdu-spi-partition.
+#
+# allow_merge_commit: also required because the workflow (and the documented
+# human fallback) uses merge commits. Enabling auto-merge alone still leaves
+# "Create a merge commit" unavailable on repos where merge commits are disabled
+# by org policy or manual toggle.
 
 echo "==> Configuring repository settings..."
 
 if $DRY_RUN; then
-  echo "    [DRY RUN] Would enable allow_auto_merge=true on $REPO"
+  echo "    [DRY RUN] Would enable allow_auto_merge=true and allow_merge_commit=true on $REPO"
 else
-  gh api --method PATCH "repos/$REPO" -F allow_auto_merge=true >/dev/null
-  echo "    Enabled allow_auto_merge"
+  gh api --method PATCH "repos/$REPO" \
+    -F allow_auto_merge=true \
+    -F allow_merge_commit=true >/dev/null
+  echo "    Enabled allow_auto_merge and allow_merge_commit"
 fi
 
 echo ""

--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -689,10 +689,14 @@ jobs:
           # that approval before firing. This locks the merge method in code so
           # release PRs cannot be squash-merged, which would break fork_upstream
           # ancestry and trigger the cascade-monitor duplicate-PR loop.
-          if gh pr merge "$PR_NUMBER" --auto --merge 2>/dev/null; then
+          # Capture combined output so a failure reason (auto-merge disabled,
+          # merge commits disabled, missing permissions, etc.) shows up in the
+          # warning — otherwise operators can't tell why arming failed.
+          if MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --auto --merge 2>&1); then
             echo "✅ Auto-merge armed with merge-commit method - awaiting human approval"
           else
-            echo "::warning::Could not arm auto-merge on PR #$PR_NUMBER. Human must merge with 'Create a merge commit' (NOT squash) - squashing breaks the cascade ancestry check."
+            MERGE_REASON=$(printf '%s' "$MERGE_OUTPUT" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')
+            echo "::warning::Could not arm auto-merge on PR #$PR_NUMBER. Reason: $MERGE_REASON Human must merge with 'Create a merge commit' (NOT squash) - squashing breaks the cascade ancestry check."
           fi
           
           # Update original tracking issue

--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -698,8 +698,13 @@ jobs:
           # Update original tracking issue
           TRACKING_ISSUE="${{ github.event.inputs.issue_number }}"
           if [ -n "$TRACKING_ISSUE" ] && [ "${{ needs.cascade-to-integration.outputs.issue_valid }}" = "true" ]; then
+            # Clean up any failure-state labels from a prior failed cascade attempt.
+            # The success path needs to remove cascade-blocked / cascade-failed so a
+            # recovered cascade leaves the tracking issue in a clean state.
             gh issue edit "$TRACKING_ISSUE" \
               --remove-label "cascade-active" \
+              --remove-label "cascade-blocked" \
+              --remove-label "cascade-failed" \
               --add-label "validated"
             
             gh issue comment "$TRACKING_ISSUE" --body "🎯 **Production PR Created** - $(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/.github/template-workflows/cascade.yml
+++ b/.github/template-workflows/cascade.yml
@@ -682,9 +682,18 @@ jobs:
           
           echo "Main PR created: $PR_URL"
           PR_NUMBER=$(basename $PR_URL)
-          
-          # All production PRs require human review - no auto-merge
-          echo "Production PR requires manual review before merge"
+
+          # Arm auto-merge with merge-commit method. The human gate is preserved
+          # by the required approval rule on main (Default Branch Protection
+          # ruleset, required_approving_review_count: 1) — auto-merge waits for
+          # that approval before firing. This locks the merge method in code so
+          # release PRs cannot be squash-merged, which would break fork_upstream
+          # ancestry and trigger the cascade-monitor duplicate-PR loop.
+          if gh pr merge "$PR_NUMBER" --auto --merge 2>/dev/null; then
+            echo "✅ Auto-merge armed with merge-commit method - awaiting human approval"
+          else
+            echo "::warning::Could not arm auto-merge on PR #$PR_NUMBER. Human must merge with 'Create a merge commit' (NOT squash) - squashing breaks the cascade ancestry check."
+          fi
           
           # Update original tracking issue
           TRACKING_ISSUE="${{ github.event.inputs.issue_number }}"

--- a/doc/src/adr/009-asymmetric-cascade-review-strategy.md
+++ b/doc/src/adr/009-asymmetric-cascade-review-strategy.md
@@ -92,8 +92,14 @@ PR_URL=$(gh pr create \
   --body "$PR_BODY" \
   --label "upstream-sync,human-required")
 
-# Arm auto-merge with merge-commit method (see Revision below)
-gh pr merge "$PR_NUMBER" --auto --merge
+# Arm auto-merge with merge-commit method (see Revision below).
+# Wrapped in if/else so a failure to arm auto-merge is logged but does
+# not fail the cascade — humans can still merge manually as a fallback.
+if MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --auto --merge 2>&1); then
+  echo "✅ Auto-merge armed - awaiting human approval"
+else
+  echo "::warning::Could not arm auto-merge on PR #$PR_NUMBER. Reason: $MERGE_OUTPUT"
+fi
 
 # Update tracking issue - production PR created
 gh issue comment "$TRACKING_ISSUE" --body "🎯 **Production PR Created** - $(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -127,7 +133,7 @@ The original asymmetric strategy is preserved — humans still gate production. 
 
 ### Implementation
 
-```yaml
+```bash
 # Cascade workflow, immediately after gh pr create:
 PR_NUMBER=$(basename $PR_URL)
 

--- a/doc/src/adr/009-asymmetric-cascade-review-strategy.md
+++ b/doc/src/adr/009-asymmetric-cascade-review-strategy.md
@@ -1,7 +1,7 @@
 # ADR-009: Asymmetric Cascade Review Strategy
 
 ## Status
-Accepted  
+Accepted (revised Apr 2026 — see "Revision: Merge Method Enforcement" below)
 
 ## Context
 The cascade workflow moves upstream changes through a three-branch hierarchy:
@@ -92,13 +92,66 @@ PR_URL=$(gh pr create \
   --body "$PR_BODY" \
   --label "upstream-sync,human-required")
 
+# Arm auto-merge with merge-commit method (see Revision below)
+gh pr merge "$PR_NUMBER" --auto --merge
+
 # Update tracking issue - production PR created
 gh issue comment "$TRACKING_ISSUE" --body "🎯 **Production PR Created** - $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 Integration completed successfully! Production PR has been created and is ready for final review."
 
-# All production PRs require manual review (implicit)
+# Human gate: approving the PR releases auto-merge
 ```
+
+## Revision: Merge Method Enforcement (Apr 2026)
+
+### Trigger
+The first cascade release PR on `osdu-spi-partition` was squash-merged by a human picking the GitHub UI's default button. The squash collapsed multiple upstream commits into one new commit on `main` that didn't share git ancestry with the original upstream commits. Two cascading consequences followed:
+
+1. `fork_upstream` was no longer a true ancestor of `main`. Cascade Monitor's `git rev-list fork_integration..fork_upstream` graph check started returning non-zero, so the monitor auto-dispatched cascade on every cron tick, creating duplicate "Upstream Integration to Main" PRs with the same upstream SHA.
+2. Subsequent cascades hit phantom merge conflicts on every file the squash had collapsed. Git couldn't reconcile main's squash blob with `fork_upstream`'s individual commits because the merge-base reverted to a point before the squash.
+
+The root vulnerability was that the human review gate and the merge-method choice were collapsed into a single click. A human reviewing a release PR could approve the changes correctly *and* misclick the merge method, with no separate gate to catch the merge-method mistake.
+
+A contributing factor was the template's `default-branch.json` ruleset including `required_linear_history`, which forbids merge commits in the GitHub UI regardless of repo settings. With merge commits hidden from the UI, "Squash" became the sticky default. That rule was removed alongside this revision.
+
+### Decision
+Separate the human review gate from the merge-method choice:
+
+- **Human gate becomes "approve the PR"**, expressed via the existing `required_approving_review_count: 1` rule on `main`.
+- **Merge method becomes workflow-enforced**, via `gh pr merge --auto --merge` armed by the cascade workflow immediately after the release PR is created.
+
+Auto-merge waits for both the required approval and any required status checks before firing. When it fires, it uses the merge-commit method that was armed by the workflow, not whatever sticky default the human had in the UI.
+
+The original asymmetric strategy is preserved — humans still gate production. The mechanism for expressing that gate moves from "click the right merge button" to "approve the PR." Both are explicit human actions, but approval has no dropdown of conflicting choices, so the merge-method foot-gun is eliminated.
+
+### Implementation
+
+```yaml
+# Cascade workflow, immediately after gh pr create:
+PR_NUMBER=$(basename $PR_URL)
+
+# Arm auto-merge with merge-commit method. The human gate is preserved
+# by the required approval rule on main — auto-merge waits for that
+# approval before firing. Locks the merge method in code so release PRs
+# cannot be squash-merged.
+if gh pr merge "$PR_NUMBER" --auto --merge 2>/dev/null; then
+  echo "✅ Auto-merge armed - awaiting human approval"
+else
+  echo "::warning::Could not arm auto-merge. Human must merge with 'Create a merge commit' (NOT squash)."
+fi
+```
+
+### Prerequisites
+- `allow_auto_merge=true` on the repository (set during init by `setup-fork-repo.sh`)
+- `required_approving_review_count: 1` (or higher) on `main` via branch protection or ruleset
+- No `required_linear_history` rule on `main` (it forbids merge commits and would block the auto-merge)
+
+### Recovery (Reversibility)
+A human can disable auto-merge from the PR UI at any time and merge manually. The escape hatch is preserved — the workflow only sets the *default* path; humans retain full control if they need to override.
+
+### Why this is consistent with the original ADR
+The original decision says "All production PRs require manual approval before merge." That remains true. The revision only changes how that approval is *expressed*: approval was previously implicit in the merge-button click, now it's explicit via the Files Changed → Approve action. The asymmetry between the two cascade phases is unchanged — fork_upstream → fork_integration is human-initiated; fork_integration → main is human-approved.
 
 ## Alternatives Considered
 
@@ -110,6 +163,12 @@ Integration completed successfully! Production PR has been created and is ready 
 
 3. **Reversed Asymmetry**: Auto-merge first stage, manual second
    - Rejected: Backwards from a safety perspective
+
+4. **Disable squash-merge repo-wide** (considered during Apr 2026 revision)
+   - Rejected: Punishes feature-branch development for the sake of one specific PR pattern. Squash-merge is a reasonable choice for feature work.
+
+5. **Harden cascade-monitor to detect squash-merged release PRs** (considered during Apr 2026 revision)
+   - Rejected: Adds complexity to a stable safety-net workflow to defend against a failure mode that auto-merge prevents at the source. Re-evaluate only if real-world recurrence proves the prevention is insufficient.
 
 ## Related
 - [ADR-001: Three-Branch Fork Management Strategy](001-three-branch-strategy.md)


### PR DESCRIPTION
## Summary

This change enforces merge-commit method for cascade release PRs by arming auto-merge at PR creation time, preventing squash-merge incidents that break fork ancestry and trigger duplicate cascade runs.

## Key Modifications

### Cascade Workflow Auto-Merge Enforcement
- **File**: `.github/template-workflows/cascade.yml`
- Adds `gh pr merge "$PR_NUMBER" --auto --merge` immediately after creating the production PR (fork_integration → main)
- Auto-merge waits for the existing required approval rule before executing, preserving the human review gate
- Falls back to a warning if auto-merge cannot be armed, instructing humans to use "Create a merge commit" manually
- Replaces the previous comment "Production PR requires manual review before merge" with explicit auto-merge arming logic

### Repository Setup Script
- **File**: `.github/scripts/setup-fork-repo.sh`
- Adds repository settings configuration section that enables `allow_auto_merge=true` via GitHub API
- Required prerequisite for the cascade workflow's auto-merge functionality
- Includes dry-run support consistent with the script's existing pattern

### Branch Protection Ruleset
- **File**: `.github/rulesets/default-branch.json`
- Removes `required_linear_history` rule from the default branch protection
- This rule previously forced squash-merge as the only available option in the GitHub UI by forbidding merge commits
- Removal allows merge commits, which the cascade workflow now enforces programmatically

### ADR-009 Documentation Update
- **File**: `doc/src/adr/009-asymmetric-cascade-review-strategy.md`
- Adds "Revision: Merge Method Enforcement (Apr 2026)" section documenting the incident that triggered this change
- Documents the squash-merge incident on `osdu-spi-partition` where a human misclick broke fork ancestry, causing cascade-monitor to create duplicate PRs on every cron tick and introducing phantom merge conflicts
- Explains the root cause: human review gate and merge-method choice were collapsed into a single UI action with no separate validation
- Updates code examples to show the new auto-merge arming step
- Adds prerequisites section listing `allow_auto_merge=true`, required approval count, and absence of `required_linear_history`
- Documents recovery path: humans can disable auto-merge from PR UI and merge manually if needed
- Adds rejected alternatives including repo-wide squash-merge disabling and cascade-monitor hardening