### PR TITLE
feat(ci): add the SPI Stack CI/CD deploy lane

### DIFF
--- a/.github/actions/aks-deploy/action.yml
+++ b/.github/actions/aks-deploy/action.yml
@@ -107,15 +107,19 @@ runs:
       # NOTE: the suspend flag lives on the Kustomizations, not the GitRepository source --
       # source-suspend (ADR-014) alone does NOT stop reconciliation from the cached artifact.
       run: |
-        all=$(kubectl get kustomizations -n "$FLUX_NS" -o json 2>/dev/null | jq -r '.items[].metadata.name')
+        if ! kustomizations_json=$(kubectl get kustomizations -n "$FLUX_NS" -o json 2>&1); then
+          echo "::error::Cannot list Flux Kustomizations in '$FLUX_NS'. Re-run spi onboard to reconcile Flux read RBAC. kubectl: $kustomizations_json"
+          exit 1
+        fi
+        all=$(jq -r '.items[].metadata.name' <<< "$kustomizations_json")
         if [ -z "$all" ]; then
           # A vacuous "0 unsuspended" would be a false negative. If the namespace has no
           # Kustomizations, flux_namespace is almost certainly wrong (this stack uses osdu-flux).
           echo "::error::No Flux Kustomizations found in namespace '$FLUX_NS' -- wrong flux_namespace? Refusing to deploy without verifying CI mode."
           exit 1
         fi
-        running=$(kubectl get kustomizations -n "$FLUX_NS" -o json \
-          | jq -r '.items[] | select(.spec.suspend != true) | .metadata.name')
+        running=$(jq -r '.items[] | select(.spec.suspend != true) | .metadata.name' \
+          <<< "$kustomizations_json")
         if [ -n "$running" ]; then
           echo "::error::Flux Kustomizations not suspended in $FLUX_NS: $running. Cluster is not in CI mode (ADR-020/ADR-032). Run: spi reconcile --suspend (or flux suspend kustomization --all -n $FLUX_NS)"
           exit 1
@@ -124,8 +128,12 @@ runs:
         # HelmRelease's own reconcile loop from drift-correcting our `kubectl set image`
         # back to the chart's pinned image (ADR-020). Assert the HelmReleases are suspended
         # too -- `spi reconcile --suspend` freezes Kustomizations AND HelmReleases.
-        hr=$(kubectl get helmrelease -n "$FLUX_NS" -o json 2>/dev/null \
-          | jq -r '.items[] | select(.spec.suspend != true) | .metadata.name')
+        if ! helmreleases_json=$(kubectl get helmrelease -n "$FLUX_NS" -o json 2>&1); then
+          echo "::error::Cannot list Flux HelmReleases in '$FLUX_NS'. Re-run spi onboard to reconcile Flux read RBAC. kubectl: $helmreleases_json"
+          exit 1
+        fi
+        hr=$(jq -r '.items[] | select(.spec.suspend != true) | .metadata.name' \
+          <<< "$helmreleases_json")
         if [ -n "$hr" ]; then
           echo "::error::Flux HelmReleases not suspended in $FLUX_NS: $hr. Cluster is not in CI mode (ADR-020/ADR-032). Run: spi reconcile --suspend (or flux suspend helmrelease --all -n $FLUX_NS)"
           exit 1
@@ -136,16 +144,11 @@ runs:
     - name: 'Capture previous digest (for restore)'
       id: capture-previous
       shell: bash
-      # Derive the pod selector from the live Deployment rather than assuming a label
-      # convention -- chart-prefixed names vary across services.
       run: |
-        SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
-          -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
-        # Only sample a Running, non-terminating pod whose target container is Ready, so a
-        # still-draining previous-RS pod (rolling update) can't yield a stale/foreign digest.
-        IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
-          | jq -r --arg c "$CONTAINER_NAME" '[.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID] | .[0] // ""')
-        DIGEST="${IMAGE_ID##*@}"
+        IMAGE=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" -o json \
+          | jq -r --arg c "$CONTAINER_NAME" '.spec.template.spec.containers[] | select(.name==$c) | .image')
+        DIGEST="${IMAGE##*@}"
+        if [ "$DIGEST" = "$IMAGE" ]; then DIGEST=""; fi
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         echo "Previous digest: ${DIGEST:-<none>}"
       env:
@@ -181,21 +184,20 @@ runs:
       run: |
         SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
           -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
-        # Only sample a Running, non-terminating pod whose target container is Ready, so a
-        # still-draining previous-RS pod (rolling update) can't yield a stale/foreign digest.
-        IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
-          | jq -r --arg c "$CONTAINER_NAME" '[.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID] | .[0] // ""')
-        DIGEST="${IMAGE_ID##*@}"
-        if [ -z "$DIGEST" ]; then
-          echo "::error::Could not read deployed digest for container '$CONTAINER_NAME' in deployment/$DEPLOYMENT_NAME."
+        DIGESTS=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
+          | jq -r --arg c "$CONTAINER_NAME" '.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID | split("@")[-1]' \
+          | sort -u)
+        if ! grep -Fxq "$EXPECTED" <<< "$DIGESTS"; then
+          echo "::error::No ready, non-terminating pod is running expected digest '$EXPECTED'. Observed: ${DIGESTS:-<none>}."
           exit 1
         fi
-        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-        echo "Deployed digest: ${DIGEST}"
+        echo "digest=${EXPECTED}" >> "$GITHUB_OUTPUT"
+        echo "Deployed digest: ${EXPECTED}"
       env:
         DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
         CONTAINER_NAME: ${{ inputs.container_name }}
         NS: ${{ inputs.namespace }}
+        EXPECTED: ${{ inputs.image_digest }}
 
     - name: 'Collect diagnostics on failure'
       if: failure()

--- a/.github/actions/aks-deploy/action.yml
+++ b/.github/actions/aks-deploy/action.yml
@@ -131,8 +131,10 @@ runs:
       run: |
         SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
           -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
+        # Only sample a Running, non-terminating pod whose target container is Ready, so a
+        # still-draining previous-RS pod (rolling update) can't yield a stale/foreign digest.
         IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
-          | jq -r --arg c "$CONTAINER_NAME" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
+          | jq -r --arg c "$CONTAINER_NAME" '[.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID] | .[0] // ""')
         DIGEST="${IMAGE_ID##*@}"
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         echo "Previous digest: ${DIGEST:-<none>}"
@@ -169,8 +171,10 @@ runs:
       run: |
         SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
           -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
+        # Only sample a Running, non-terminating pod whose target container is Ready, so a
+        # still-draining previous-RS pod (rolling update) can't yield a stale/foreign digest.
         IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
-          | jq -r --arg c "$CONTAINER_NAME" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
+          | jq -r --arg c "$CONTAINER_NAME" '[.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID] | .[0] // ""')
         DIGEST="${IMAGE_ID##*@}"
         if [ -z "$DIGEST" ]; then
           echo "::error::Could not read deployed digest for container '$CONTAINER_NAME' in deployment/$DEPLOYMENT_NAME."

--- a/.github/actions/aks-deploy/action.yml
+++ b/.github/actions/aks-deploy/action.yml
@@ -1,0 +1,208 @@
+# Deploy a service image to the shared spi-stack AKS cluster, by digest.
+#
+# CALLER REQUIREMENTS (composite actions cannot declare permissions or install tools):
+#   - The calling workflow job MUST set `permissions: { id-token: write, contents: read }`
+#     so azure/login can request the federated OIDC token.
+#   - The caller MUST have already installed `kubectl` and `kubelogin` on the runner
+#     (e.g. azure/setup-kubectl + a kubelogin install step). `az` is provided by azure/login.
+#   - Cluster auth is Entra-only + Azure RBAC for Kubernetes (Phase 0 gate 0b), so this action
+#     runs `kubelogin convert-kubeconfig -l azurecli` after fetching credentials.
+#
+# Reference: design doc §5.2 (Deploy) + Appendix A.3. Trust boundary lives on the caller
+# job (§5.5 / ADR-036) -- this action never decides whether it is safe to run.
+
+name: 'AKS Deploy (set image by digest)'
+description: >-
+  OIDC login, assert Flux is suspended (CI mode), `kubectl set image` by digest, wait for
+  rollout, and emit the previous + deployed digests. By digest only -- tags are never accepted.
+
+inputs:
+  azure_client_id:
+    description: 'Federated-identity client ID for OIDC login (repo secret AZURE_CLIENT_ID).'
+    required: true
+  azure_tenant_id:
+    description: 'Entra tenant ID (repo secret AZURE_TENANT_ID).'
+    required: true
+  azure_subscription_id:
+    description: 'Subscription ID (repo secret AZURE_SUBSCRIPTION_ID).'
+    required: true
+  aks_resource_group:
+    description: 'Resource group of the AKS cluster (org variable AKS_RESOURCE_GROUP).'
+    required: true
+  aks_cluster_name:
+    description: 'AKS cluster name (org variable AKS_CLUSTER_NAME).'
+    required: true
+  namespace:
+    description: 'Target Kubernetes namespace (org variable K8S_NAMESPACE, e.g. osdu).'
+    required: true
+  deployment_name:
+    description: 'Deployment to patch -- per-service variable K8S_DEPLOYMENT_NAME (NOT derived from SERVICE_NAME; see D13).'
+    required: true
+  container_name:
+    description: 'Container within the Deployment to set -- per-service variable K8S_CONTAINER_NAME.'
+    required: true
+  image_repository:
+    description: 'Image repository without tag/digest, e.g. ghcr.io/<org>/<service>.'
+    required: true
+  image_digest:
+    description: 'Image digest INCLUDING the sha256: prefix, e.g. sha256:abc123... The deploy reference is composed as <image_repository>@<image_digest>. Tags are not accepted.'
+    required: true
+  rollout_timeout:
+    description: 'kubectl rollout status timeout.'
+    required: false
+    default: '5m'
+  flux_namespace:
+    description: 'Namespace holding the spi-stack Flux Kustomizations, for the CI-mode suspend pre-check. Defaults to flux-system; THIS stack uses osdu-flux (the AKS Flux extension is configured there). Wire from an org variable so it tracks the cluster.'
+    required: false
+    default: 'flux-system'
+
+outputs:
+  previous_digest:
+    description: 'sha256 digest running BEFORE this deploy (captured pre-patch; consumed by restore-deployment.yml per §8.9). Empty when nothing was running.'
+    value: ${{ steps.capture-previous.outputs.digest }}
+  deployed_digest:
+    description: 'sha256 digest running AFTER rollout (read from the live pod; for downstream pin-verification in integration-test).'
+    value: ${{ steps.verify.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Azure login (OIDC)'
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
+
+    - name: 'Validate image digest format'
+      shell: bash
+      # Catch the "double sha256:" foot-gun and tag-as-digest mistakes before kubectl runs.
+      run: |
+        if ! printf '%s' "$IMAGE_DIGEST" | grep -Eq '^sha256:[a-f0-9]{64}$'; then
+          echo "::error::image_digest must match ^sha256:[a-f0-9]{64}$ (got: '$IMAGE_DIGEST'). Pass a digest, never a tag."
+          exit 1
+        fi
+      env:
+        IMAGE_DIGEST: ${{ inputs.image_digest }}
+
+    - name: 'Get AKS credentials'
+      shell: bash
+      # Entra-only cluster with Azure RBAC (gate 0b): convert to the azurecli exec plugin so
+      # kubectl uses the az CLI token non-interactively. Caller must have kubelogin installed.
+      run: |
+        az aks get-credentials \
+          --resource-group "$RG" \
+          --name "$CLUSTER" \
+          --overwrite-existing \
+          --only-show-errors
+        kubelogin convert-kubeconfig -l azurecli
+      env:
+        RG: ${{ inputs.aks_resource_group }}
+        CLUSTER: ${{ inputs.aks_cluster_name }}
+
+    - name: 'Assert Flux suspended (pre-flight, §7.5 CI-mode invariant)'
+      shell: bash
+      # Fail fast if the cluster is not in CI mode: an unsuspended Kustomization reverts our
+      # `kubectl set image` within its reconcile interval via Helm drift correction.
+      # NOTE: the suspend flag lives on the Kustomizations, not the GitRepository source --
+      # source-suspend (ADR-014) alone does NOT stop reconciliation from the cached artifact.
+      run: |
+        all=$(kubectl get kustomizations -n "$FLUX_NS" -o json 2>/dev/null | jq -r '.items[].metadata.name')
+        if [ -z "$all" ]; then
+          # A vacuous "0 unsuspended" would be a false negative. If the namespace has no
+          # Kustomizations, flux_namespace is almost certainly wrong (this stack uses osdu-flux).
+          echo "::error::No Flux Kustomizations found in namespace '$FLUX_NS' -- wrong flux_namespace? Refusing to deploy without verifying CI mode."
+          exit 1
+        fi
+        running=$(kubectl get kustomizations -n "$FLUX_NS" -o json \
+          | jq -r '.items[] | select(.spec.suspend != true) | .metadata.name')
+        if [ -n "$running" ]; then
+          echo "::error::Flux Kustomizations not suspended in $FLUX_NS: $running. Cluster is not in CI mode (see ADR-032 / §7.5). Run: flux suspend kustomization --all -n $FLUX_NS"
+          exit 1
+        fi
+      env:
+        FLUX_NS: ${{ inputs.flux_namespace }}
+
+    - name: 'Capture previous digest (for restore)'
+      id: capture-previous
+      shell: bash
+      # Derive the pod selector from the live Deployment rather than assuming a label
+      # convention -- chart-prefixed names vary across services.
+      run: |
+        SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
+          -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
+        IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
+          | jq -r --arg c "$CONTAINER_NAME" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
+        DIGEST="${IMAGE_ID##*@}"
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        echo "Previous digest: ${DIGEST:-<none>}"
+      env:
+        DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        CONTAINER_NAME: ${{ inputs.container_name }}
+        NS: ${{ inputs.namespace }}
+
+    - name: 'Set image (by digest)'
+      shell: bash
+      run: |
+        kubectl set image "deployment/$DEPLOYMENT_NAME" \
+          "$CONTAINER_NAME=$IMAGE_REPOSITORY@$IMAGE_DIGEST" \
+          -n "$NS"
+      env:
+        DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        CONTAINER_NAME: ${{ inputs.container_name }}
+        IMAGE_REPOSITORY: ${{ inputs.image_repository }}
+        IMAGE_DIGEST: ${{ inputs.image_digest }}
+        NS: ${{ inputs.namespace }}
+
+    - name: 'Wait for rollout'
+      shell: bash
+      run: |
+        kubectl rollout status "deployment/$DEPLOYMENT_NAME" -n "$NS" --timeout="$TIMEOUT"
+      env:
+        DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        NS: ${{ inputs.namespace }}
+        TIMEOUT: ${{ inputs.rollout_timeout }}
+
+    - name: 'Capture deployed digest (post-rollout verification)'
+      id: verify
+      shell: bash
+      run: |
+        SELECTOR=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$NS" \
+          -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
+        IMAGE_ID=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
+          | jq -r --arg c "$CONTAINER_NAME" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
+        DIGEST="${IMAGE_ID##*@}"
+        if [ -z "$DIGEST" ]; then
+          echo "::error::Could not read deployed digest for container '$CONTAINER_NAME' in deployment/$DEPLOYMENT_NAME."
+          exit 1
+        fi
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        echo "Deployed digest: ${DIGEST}"
+      env:
+        DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        CONTAINER_NAME: ${{ inputs.container_name }}
+        NS: ${{ inputs.namespace }}
+
+    - name: 'Collect diagnostics on failure'
+      if: failure()
+      shell: bash
+      run: |
+        mkdir -p deploy-diagnostics
+        {
+          echo "### deployment/$DEPLOYMENT_NAME (namespace $NS)"
+          kubectl describe "deployment/$DEPLOYMENT_NAME" -n "$NS" 2>&1 || true
+          echo
+          echo "### recent pod logs (--tail=200)"
+          kubectl logs "deployment/$DEPLOYMENT_NAME" -n "$NS" --tail=200 --all-containers 2>&1 || true
+        } > "deploy-diagnostics/${DEPLOYMENT_NAME}.txt"
+      env:
+        DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        NS: ${{ inputs.namespace }}
+
+    - name: 'Upload failure diagnostics'
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: aks-deploy-diagnostics-${{ inputs.deployment_name }}
+        path: deploy-diagnostics/
+        if-no-files-found: ignore

--- a/.github/actions/aks-deploy/action.yml
+++ b/.github/actions/aks-deploy/action.yml
@@ -117,7 +117,17 @@ runs:
         running=$(kubectl get kustomizations -n "$FLUX_NS" -o json \
           | jq -r '.items[] | select(.spec.suspend != true) | .metadata.name')
         if [ -n "$running" ]; then
-          echo "::error::Flux Kustomizations not suspended in $FLUX_NS: $running. Cluster is not in CI mode (see ADR-032 / §7.5). Run: flux suspend kustomization --all -n $FLUX_NS"
+          echo "::error::Flux Kustomizations not suspended in $FLUX_NS: $running. Cluster is not in CI mode (ADR-020/ADR-032). Run: spi reconcile --suspend (or flux suspend kustomization --all -n $FLUX_NS)"
+          exit 1
+        fi
+        # Services are HelmRelease-managed; a suspended Kustomization does NOT stop the
+        # HelmRelease's own reconcile loop from drift-correcting our `kubectl set image`
+        # back to the chart's pinned image (ADR-020). Assert the HelmReleases are suspended
+        # too -- `spi reconcile --suspend` freezes Kustomizations AND HelmReleases.
+        hr=$(kubectl get helmrelease -n "$FLUX_NS" -o json 2>/dev/null \
+          | jq -r '.items[] | select(.spec.suspend != true) | .metadata.name')
+        if [ -n "$hr" ]; then
+          echo "::error::Flux HelmReleases not suspended in $FLUX_NS: $hr. Cluster is not in CI mode (ADR-020/ADR-032). Run: spi reconcile --suspend (or flux suspend helmrelease --all -n $FLUX_NS)"
           exit 1
         fi
       env:

--- a/.github/actions/cluster-health-check/action.yml
+++ b/.github/actions/cluster-health-check/action.yml
@@ -1,0 +1,105 @@
+# Pre-flight cluster health probe for the deploy lane.
+#
+# Distinguishes "the cluster is down / not in CI mode" from "your code is broken" so a PR
+# author is not blamed for an infra outage (§8.4). Used by the deploy job and (optionally)
+# by a scheduled health-badge workflow.
+#
+# CALLER REQUIREMENTS (composite actions cannot install tools or log in):
+#   - The caller MUST have already authenticated to Azure (azure/login) and pulled cluster
+#     credentials (az aks get-credentials + kubelogin convert-kubeconfig -l azurecli) before
+#     invoking this action -- it takes NO Azure inputs and does NOT run login. Without that,
+#     kubectl calls fail with a confusing "cluster unreachable" error.
+#   - kubectl + kubelogin must be on the runner.
+#
+# Reference: design doc §8.4 + §7.5 (CI-mode invariant).
+
+name: 'Cluster Health Check (deploy pre-flight)'
+description: >-
+  Verify the spi-stack cluster is reachable and in CI mode: nodes Ready, gateway returns 2xx,
+  and Flux Kustomizations are suspended. Emits a status so callers can fail fast with a clear
+  "infra is down" signal rather than a misleading deploy error.
+
+inputs:
+  gateway_url:
+    description: 'Base gateway URL to probe, e.g. https://<gateway-host> (org variable GATEWAY_URL).'
+    required: true
+  health_path:
+    description: 'Path appended to gateway_url for the HTTP probe.'
+    required: false
+    default: '/api/partition/v1/info'
+  flux_namespace:
+    description: 'Namespace holding the spi-stack Flux Kustomizations (this stack uses osdu-flux; default flux-system).'
+    required: false
+    default: 'flux-system'
+
+outputs:
+  status:
+    description: "'healthy' | 'degraded' | 'down'. 'down' = nodes not Ready or gateway unreachable; 'degraded' = reachable but an invariant (gateway non-2xx or Flux not suspended) is violated."
+    value: ${{ steps.check.outputs.status }}
+  summary:
+    description: 'One-line human-readable summary of the check result.'
+    value: ${{ steps.check.outputs.summary }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Probe cluster health'
+      id: check
+      shell: bash
+      # Each check emits a distinct message so the failing component is unambiguous. The
+      # action never logs secrets; gateway URL / namespace / node names are safe to print.
+      run: |
+        set -uo pipefail
+        STATUS=healthy
+        DETAILS=""
+
+        fail_down()    { STATUS=down;     DETAILS="${DETAILS}${1}; "; }
+        fail_degraded(){ if [ "$STATUS" != "down" ]; then STATUS=degraded; fi; DETAILS="${DETAILS}${1}; "; }
+
+        # 1. Nodes Ready -- if the API server is unreachable this also catches "cluster down".
+        if ! NODE_JSON=$(kubectl get nodes -o json 2>/dev/null); then
+          fail_down "API server unreachable (kubectl get nodes failed)"
+        else
+          NOT_READY=$(jq -r '.items[] | select((.status.conditions[] | select(.type=="Ready") | .status) != "True") | .metadata.name' <<< "$NODE_JSON")
+          if [ -n "$NOT_READY" ]; then
+            fail_down "Nodes not Ready: $(echo "$NOT_READY" | tr "\n" " ")"
+          fi
+        fi
+
+        # 2. Gateway returns 2xx.
+        CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "${GATEWAY_URL}${HEALTH_PATH}" || echo "000")
+        if [ "$CODE" = "000" ]; then
+          fail_down "Gateway unreachable at ${GATEWAY_URL}${HEALTH_PATH}"
+        elif [ "$CODE" -lt 200 ] || [ "$CODE" -ge 300 ]; then
+          fail_degraded "Gateway returned HTTP ${CODE} at ${GATEWAY_URL}${HEALTH_PATH}"
+        fi
+
+        # 3. Flux Kustomizations suspended (CI-mode invariant, §7.5). A namespace with zero
+        #    Kustomizations almost certainly means the wrong flux_namespace -> treat as degraded.
+        if ! K_JSON=$(kubectl get kustomizations -n "$FLUX_NS" -o json 2>/dev/null); then
+          fail_degraded "Could not list Kustomizations in '$FLUX_NS' (wrong flux_namespace, or Flux CRDs absent?)"
+        else
+          COUNT=$(jq -r '.items | length' <<< "$K_JSON")
+          if [ "$COUNT" -eq 0 ]; then
+            fail_degraded "No Kustomizations found in '$FLUX_NS' -- cannot confirm CI mode (wrong flux_namespace?)"
+          else
+            RUNNING=$(jq -r '.items[] | select(.spec.suspend != true) | .metadata.name' <<< "$K_JSON")
+            if [ -n "$RUNNING" ]; then
+              fail_degraded "Flux not suspended in ${FLUX_NS}: $(echo "$RUNNING" | tr "\n" " ") (cluster not in CI mode)"
+            fi
+          fi
+        fi
+
+        [ -n "$DETAILS" ] || DETAILS="nodes Ready, gateway 2xx, Flux suspended"
+        echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+        echo "summary=$DETAILS" >> "$GITHUB_OUTPUT"
+        {
+          echo "### Cluster health: \`${STATUS}\`"
+          echo ""
+          echo "- ${DETAILS}"
+        } >> "$GITHUB_STEP_SUMMARY"
+        echo "Cluster health: $STATUS -- $DETAILS"
+      env:
+        GATEWAY_URL: ${{ inputs.gateway_url }}
+        HEALTH_PATH: ${{ inputs.health_path }}
+        FLUX_NS: ${{ inputs.flux_namespace }}

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -126,7 +126,22 @@ outputs:
     value: ${{ steps.health.outputs.cluster_state }}
   test_report_url:
     description: 'Link to the uploaded JUnit XML artifact (empty if none produced).'
-    value: ${{ steps.report.outputs.url }}
+    value: ${{ steps.report.outputs.artifact-url }}
+  tests:
+    description: 'Number of tests reported by Surefire/Failsafe XML.'
+    value: ${{ steps.junit.outputs.tests }}
+  failures:
+    description: 'Number of JUnit assertion failures.'
+    value: ${{ steps.junit.outputs.failures }}
+  errors:
+    description: 'Number of JUnit execution errors.'
+    value: ${{ steps.junit.outputs.errors }}
+  skipped:
+    description: 'Number of skipped or disabled tests.'
+    value: ${{ steps.junit.outputs.skipped }}
+  attempts:
+    description: 'Number of retry-wrapper attempts used.'
+    value: ${{ steps.tests.outputs.total_attempts }}
 
 runs:
   using: composite
@@ -377,6 +392,18 @@ runs:
           if [ -n "${{ inputs.maven_profile }}" ]; then PROFILE_ARG="-P ${{ inputs.maven_profile }}"; fi
           GATEWAY_URL="${{ inputs.gateway_url }}" mvn --batch-mode --no-transfer-progress $PROFILE_ARG ${{ inputs.maven_goal }}
 
+    - name: 'Summarize JUnit results'
+      id: junit
+      if: always()
+      shell: bash
+      run: |
+        python "$ACTION_PATH/summarize_junit.py" \
+          --test-dir "$TEST_DIR" \
+          --github-output "$GITHUB_OUTPUT"
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        TEST_DIR: ${{ inputs.test_dir }}
+
     - name: 'Upload JUnit results'
       id: report
       if: always()
@@ -394,7 +421,6 @@ runs:
       shell: bash
       # Binary exit on the TEST outcome; cluster_state only annotates (pass-advisory + label).
       run: |
-        echo "url=${ARTIFACT_URL}" >> "$GITHUB_OUTPUT"
         if [ "$TESTS_OUTCOME" = "success" ]; then
           if [ "$CLUSTER_STATE" = "contaminated" ]; then
             RESULT="pass-advisory"
@@ -405,16 +431,51 @@ runs:
           RESULT="fail"
         fi
         echo "test_result=$RESULT" >> "$GITHUB_OUTPUT"
+        case "$RESULT" in
+          pass) RESULT_LABEL="✅ Pass" ;;
+          pass-advisory) RESULT_LABEL="⚠️ Pass (advisory)" ;;
+          *) RESULT_LABEL="❌ Fail" ;;
+        esac
+        if [ -n "$NO_DATA_TOKEN_ENV" ]; then
+          NO_DATA_LABEL="Enabled (\`$NO_DATA_TOKEN_ENV\`)"
+        else
+          NO_DATA_LABEL="Disabled"
+        fi
+        if [ "${REPORT_FILES:-0}" -gt 0 ]; then
+          TEST_LABEL="${TESTS} total · ${FAILURES} failures · ${ERRORS} errors · ${SKIPPED} skipped"
+          DURATION_LABEL="${DURATION_DISPLAY}"
+        else
+          TEST_LABEL="No JUnit XML reports found"
+          DURATION_LABEL="n/a"
+        fi
+        if [ -n "$ARTIFACT_URL" ]; then
+          ARTIFACT_LABEL="[Download JUnit XML]($ARTIFACT_URL)"
+        else
+          ARTIFACT_LABEL="Not available"
+        fi
         {
           echo "### 🧪 Integration Tests"
           echo ""
-          echo "- Service: \`${DEPLOYMENT}\`"
-          echo "- Result: \`${RESULT}\`"
-          echo "- Cluster state at start: \`${CLUSTER_STATE}\`"
+          echo "| Field | Value |"
+          echo "| --- | --- |"
+          echo "| Service | \`${DEPLOYMENT}\` |"
+          echo "| Result | ${RESULT_LABEL} |"
+          echo "| Tests | ${TEST_LABEL} |"
+          echo "| Test duration | ${DURATION_LABEL} |"
+          echo "| Retry attempts | ${ATTEMPTS:-0} |"
+          echo "| Cluster state at start | \`${CLUSTER_STATE:-unavailable}\` |"
+          echo "| Deployed digest | \`${EXPECTED_DIGEST}\` |"
+          echo "| No-data authorization | ${NO_DATA_LABEL} |"
+          echo "| JUnit artifact | ${ARTIFACT_LABEL} |"
           if [ "$RESULT" = "pass-advisory" ]; then
-            echo "- ⚠️ A dependency was unhealthy at probe time; the pass may not be fully authoritative (label \`ci/cluster-was-contaminated\`)."
+            echo ""
+            echo "> A dependency was unhealthy at probe time; the pass may not be fully authoritative."
           fi
-        } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${PARSE_ERRORS:-0}" -gt 0 ]; then
+            echo ""
+            echo "> ⚠️ ${PARSE_ERRORS} JUnit XML report(s) could not be parsed."
+          fi
+        } | tee -a "$GITHUB_STEP_SUMMARY"
         # Re-surface the real test outcome as this action's exit code.
         [ "$TESTS_OUTCOME" = "success" ]
       env:
@@ -422,3 +483,13 @@ runs:
         CLUSTER_STATE: ${{ steps.health.outputs.cluster_state }}
         DEPLOYMENT: ${{ inputs.deployment_name }}
         ARTIFACT_URL: ${{ steps.report.outputs.artifact-url }}
+        EXPECTED_DIGEST: ${{ inputs.expected_digest }}
+        NO_DATA_TOKEN_ENV: ${{ inputs.no_data_access_token_env }}
+        ATTEMPTS: ${{ steps.tests.outputs.total_attempts }}
+        TESTS: ${{ steps.junit.outputs.tests }}
+        FAILURES: ${{ steps.junit.outputs.failures }}
+        ERRORS: ${{ steps.junit.outputs.errors }}
+        SKIPPED: ${{ steps.junit.outputs.skipped }}
+        DURATION_DISPLAY: ${{ steps.junit.outputs.duration_display }}
+        REPORT_FILES: ${{ steps.junit.outputs.report_files }}
+        PARSE_ERRORS: ${{ steps.junit.outputs.parse_errors }}

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -210,6 +210,19 @@ runs:
             printf '__TOKEN_EOF__\n'
           } >> "$GITHUB_ENV"
           echo "Minted '$ROOT_TOKEN_ENV' (app-only, aud=$AAD_CLIENT_ID) as the CI identity."
+          # ADME standardizes every OSDU service IT on -DINTEGRATION_TESTER_ACCESS_TOKEN, minted
+          # without a secret via federated identity (oep-deployment-resources
+          # GenerateTokenWithoutSecret.yml). Export the same mint under that canonical name so the
+          # upstream testing/<svc>-test-azure suites consume it directly; the SPI-custom
+          # partition-acceptance-test reads ROOT_USER_TOKEN (the $ROOT_TOKEN_ENV default above).
+          if [ "$ROOT_TOKEN_ENV" != "INTEGRATION_TESTER_ACCESS_TOKEN" ]; then
+            {
+              printf 'INTEGRATION_TESTER_ACCESS_TOKEN<<__TOKEN_EOF__\n'
+              printf '%s\n' "$TOKEN"
+              printf '__TOKEN_EOF__\n'
+            } >> "$GITHUB_ENV"
+            echo "Also exported the mint as INTEGRATION_TESTER_ACCESS_TOKEN (ADME standard)."
+          fi
         fi
         if [ -n "$ENV_MAP" ] && [ "$ENV_MAP" != "{}" ]; then
           for env_name in $(jq -r 'keys[]' <<< "$ENV_MAP"); do

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -199,9 +199,19 @@ runs:
       run: |
         STATE=healthy
         if [ -n "$DEPS" ] && [ "$DEPS" != "{}" ]; then
+          # Validate before iterating: `jq -r keys[]` on malformed input prints
+          # nothing and the loop silently becomes a no-op, so a typo in
+          # ACCEPTANCE_TEST_DEPENDENCIES would read as "no dependencies" instead
+          # of a configuration error.
+          if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$DEPS"; then
+            echo "::error::dependencies must be a JSON object of service -> health path (got: $DEPS)"
+            exit 1
+          fi
           for svc in $(jq -r 'keys[]' <<< "$DEPS"); do
             path=$(jq -r --arg s "$svc" '.[$s]' <<< "$DEPS")
-            code=$(curl -s -o /dev/null -w '%{http_code}' "${GW}${path}" || echo "000")
+            # --max-time bounds a hung dependency; without it this advisory probe
+            # can stall the whole lane until the step timeout.
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "${GW}${path}" || echo "000")
             if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
               echo "::warning::Dependency '$svc' unhealthy at ${GW}${path} (HTTP $code)"
               STATE=contaminated
@@ -272,11 +282,24 @@ runs:
     - name: 'Load acceptance-test secrets from Key Vault (masked, multiline-safe)'
       shell: bash
       run: |
+        set -euo pipefail
+        if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$MAP"; then
+          echo "::error::secret_map must be a JSON object of env-var-name -> Key Vault secret name (got: $MAP)"
+          exit 1
+        fi
         for env_name in $(jq -r 'keys[]' <<< "$MAP"); do
           secret_name=$(jq -r --arg k "$env_name" '.[$k]' <<< "$MAP")
-          value=$(az keyvault secret show --vault-name "$KV" --name "$secret_name" --query value -o tsv)
-          # Mask BEFORE writing to GITHUB_ENV so it never appears in logs.
-          echo "::add-mask::$value"
+          if ! value=$(az keyvault secret show --vault-name "$KV" --name "$secret_name" --query value -o tsv); then
+            echo "::error::Could not read secret '$secret_name' from Key Vault '$KV' (for $env_name)."
+            exit 1
+          fi
+          # Mask BEFORE writing to GITHUB_ENV so it never appears in logs. Workflow
+          # commands are line-oriented, so a multiline secret must be masked line by
+          # line -- a single ::add-mask:: would register only the first line and emit
+          # the rest as ordinary log output.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$value"
           {
             printf '%s<<__SECRET_EOF__\n' "$env_name"
             printf '%s\n' "$value"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -1,0 +1,246 @@
+# Run a service's acceptance-test suite against the live spi-stack gateway, after
+# verifying the pod still runs the digest we just deployed.
+#
+# CALLER REQUIREMENTS (composite actions cannot declare permissions or install tools):
+#   - The calling workflow job MUST set `permissions: { id-token: write, contents: read }`.
+#   - The caller MUST have already run azure/login + az aks get-credentials + kubelogin
+#     (the deploy job does this; integration-test reuses the same job's kube context only if
+#     in the same job -- when in a separate job it logs in itself; see inputs azure_*).
+#   - kubectl, kubelogin, Java 17, and Maven must be available on the runner.
+#
+# ENCAPSULATION: this action takes only explicit inputs. It never reads vars.* or secrets.*
+# directly -- the workflow caller wires them in (§5.3).
+#
+# EXIT-CODE SEMANTICS (required-check compatible, §5.3): the job exit is binary on the TEST
+# outcome only. The cross-service health probe is advisory -- it sets cluster_state +
+# test_result=pass-advisory and drives a PR label, but NEVER changes the exit code.
+#
+# Reference: design doc §5.3 + Appendix A.4 + §8.6 + §8.9.
+
+name: 'Integration Test (acceptance suite vs gateway)'
+description: >-
+  Verify the deployed digest is still running, run an advisory cross-service health probe,
+  pull acceptance-test secrets from Key Vault (masked), and run the service's acceptance-test
+  Maven module against the gateway with retry-on-flake.
+
+inputs:
+  azure_client_id:
+    description: 'Federated-identity client ID for OIDC login (repo secret AZURE_CLIENT_ID).'
+    required: true
+  azure_tenant_id:
+    description: 'Entra tenant ID (repo secret AZURE_TENANT_ID).'
+    required: true
+  azure_subscription_id:
+    description: 'Subscription ID (repo secret AZURE_SUBSCRIPTION_ID).'
+    required: true
+  aks_resource_group:
+    description: 'Resource group of the AKS cluster (org variable AKS_RESOURCE_GROUP).'
+    required: true
+  aks_cluster_name:
+    description: 'AKS cluster name (org variable AKS_CLUSTER_NAME).'
+    required: true
+  test_dir:
+    description: 'Acceptance-test Maven module directory (per-service variable ACCEPTANCE_TEST_DIR; convention <service>-acceptance-test).'
+    required: true
+  namespace:
+    description: 'Target namespace (org variable K8S_NAMESPACE, e.g. osdu).'
+    required: true
+  deployment_name:
+    description: 'Deployment under test (per-service variable K8S_DEPLOYMENT_NAME).'
+    required: true
+  container_name:
+    description: 'Container within the Deployment (per-service variable K8S_CONTAINER_NAME).'
+    required: true
+  gateway_url:
+    description: 'Base gateway URL, e.g. https://<gateway-host> (org variable GATEWAY_URL).'
+    required: true
+  keyvault_name:
+    description: 'Key Vault holding acceptance-test secrets (org variable KEYVAULT_NAME).'
+    required: true
+  secret_map:
+    description: 'JSON map of env-var-name -> kv-secret-name, e.g. {"INTEGRATION_TESTER":"integration-tester-id"}. Per-service.'
+    required: true
+  expected_digest:
+    description: 'sha256 digest the deploy job set (needs.deploy.outputs.deployed_digest). The pod image is re-read and the run fails on mismatch (mid-test Flux resume / stale restart guard).'
+    required: true
+  dependencies:
+    description: 'Optional JSON map of dependency-service -> gateway health path, e.g. {"partition":"/api/partition/v1/info"}. Probed at start; advisory only (drives cluster_state + PR label, never the exit code).'
+    required: false
+    default: '{}'
+  maven_goal:
+    description: 'Maven goal for the acceptance tests.'
+    required: false
+    default: 'verify'
+  maven_profile:
+    description: 'Optional Maven profile for the acceptance-test module.'
+    required: false
+    default: ''
+  max_attempts:
+    description: 'Acceptance-test retry attempts (flaky-test mitigation, §8.6).'
+    required: false
+    default: '2'
+  timeout_minutes:
+    description: 'Per-attempt timeout for the acceptance-test run.'
+    required: false
+    default: '10'
+
+outputs:
+  test_result:
+    description: "'pass' | 'fail' | 'pass-advisory' (tests passed but a dependency was unhealthy at probe time)."
+    value: ${{ steps.result.outputs.test_result }}
+  cluster_state:
+    description: "'healthy' | 'contaminated' (cross-service health probe at start of run)."
+    value: ${{ steps.health.outputs.cluster_state }}
+  test_report_url:
+    description: 'Link to the uploaded JUnit XML artifact (empty if none produced).'
+    value: ${{ steps.report.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Azure login (OIDC)'
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+      with:
+        client-id: ${{ inputs.azure_client_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
+
+    - name: 'Get AKS credentials'
+      shell: bash
+      run: |
+        az aks get-credentials \
+          --resource-group "$RG" \
+          --name "$CLUSTER" \
+          --overwrite-existing \
+          --only-show-errors
+        kubelogin convert-kubeconfig -l azurecli
+      env:
+        RG: ${{ inputs.aks_resource_group }}
+        CLUSTER: ${{ inputs.aks_cluster_name }}
+
+    - name: 'Verify deployed digest still running'
+      shell: bash
+      # Guards against a mid-test Flux resume, a pod restart with a stale image, or a
+      # cross-service overwrite -- if the live pod is not the digest we deployed, the test
+      # result would be meaningless, so fail fast (§8.9, Appendix A.4).
+      run: |
+        if ! printf '%s' "$EXPECTED" | grep -Eq '^sha256:[a-f0-9]{64}$'; then
+          echo "::error::expected_digest must be a sha256:<64-hex> digest (got: '$EXPECTED')."
+          exit 1
+        fi
+        SELECTOR=$(kubectl get deployment "$DEPLOYMENT" -n "$NS" \
+          -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
+        CURRENT=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
+          | jq -r --arg c "$CONTAINER" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
+        CURRENT_DIGEST="${CURRENT##*@}"
+        if [ "$CURRENT_DIGEST" != "$EXPECTED" ]; then
+          echo "::error::Pod is running '${CURRENT_DIGEST:-<none>}' but deploy set '$EXPECTED'. Possible Flux resume, pod restart with stale image, or cross-service overwrite."
+          exit 1
+        fi
+        echo "Verified pod is running the expected digest: $EXPECTED"
+      env:
+        NS: ${{ inputs.namespace }}
+        DEPLOYMENT: ${{ inputs.deployment_name }}
+        CONTAINER: ${{ inputs.container_name }}
+        EXPECTED: ${{ inputs.expected_digest }}
+
+    - name: 'Cross-service health probe (advisory)'
+      id: health
+      shell: bash
+      # Advisory ONLY: sets cluster_state but never the job exit code (§5.3 exit-code table).
+      run: |
+        STATE=healthy
+        if [ -n "$DEPS" ] && [ "$DEPS" != "{}" ]; then
+          for svc in $(jq -r 'keys[]' <<< "$DEPS"); do
+            path=$(jq -r --arg s "$svc" '.[$s]' <<< "$DEPS")
+            code=$(curl -s -o /dev/null -w '%{http_code}' "${GW}${path}" || echo "000")
+            if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+              echo "::warning::Dependency '$svc' unhealthy at ${GW}${path} (HTTP $code)"
+              STATE=contaminated
+            fi
+          done
+        fi
+        echo "cluster_state=$STATE" >> "$GITHUB_OUTPUT"
+        echo "Cluster state at start of run: $STATE"
+      env:
+        DEPS: ${{ inputs.dependencies }}
+        GW: ${{ inputs.gateway_url }}
+
+    - name: 'Load acceptance-test secrets from Key Vault (masked, multiline-safe)'
+      shell: bash
+      run: |
+        for env_name in $(jq -r 'keys[]' <<< "$MAP"); do
+          secret_name=$(jq -r --arg k "$env_name" '.[$k]' <<< "$MAP")
+          value=$(az keyvault secret show --vault-name "$KV" --name "$secret_name" --query value -o tsv)
+          # Mask BEFORE writing to GITHUB_ENV so it never appears in logs.
+          echo "::add-mask::$value"
+          {
+            printf '%s<<__SECRET_EOF__\n' "$env_name"
+            printf '%s\n' "$value"
+            printf '__SECRET_EOF__\n'
+          } >> "$GITHUB_ENV"
+        done
+      env:
+        KV: ${{ inputs.keyvault_name }}
+        MAP: ${{ inputs.secret_map }}
+
+    - name: 'Run acceptance tests (retry on flake)'
+      id: tests
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+      with:
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        max_attempts: ${{ inputs.max_attempts }}
+        # GATEWAY_URL is exported so acceptance suites that read it from the environment
+        # (e.g. PARTITION_BASE_URL derivations) pick it up; KV-sourced env vars are already
+        # in GITHUB_ENV from the previous step.
+        command: |
+          cd "${{ inputs.test_dir }}"
+          PROFILE_ARG=""
+          if [ -n "${{ inputs.maven_profile }}" ]; then PROFILE_ARG="-P ${{ inputs.maven_profile }}"; fi
+          GATEWAY_URL="${{ inputs.gateway_url }}" mvn --batch-mode --no-transfer-progress $PROFILE_ARG ${{ inputs.maven_goal }}
+
+    - name: 'Upload JUnit results'
+      id: report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: integration-test-results-${{ inputs.deployment_name }}
+        path: |
+          ${{ inputs.test_dir }}/**/target/surefire-reports/*.xml
+          ${{ inputs.test_dir }}/**/target/failsafe-reports/*.xml
+        if-no-files-found: ignore
+
+    - name: 'Compute test_result + summary'
+      id: result
+      if: always()
+      shell: bash
+      # Binary exit on the TEST outcome; cluster_state only annotates (pass-advisory + label).
+      run: |
+        echo "url=${ARTIFACT_URL}" >> "$GITHUB_OUTPUT"
+        if [ "$TESTS_OUTCOME" = "success" ]; then
+          if [ "$CLUSTER_STATE" = "contaminated" ]; then
+            RESULT="pass-advisory"
+          else
+            RESULT="pass"
+          fi
+        else
+          RESULT="fail"
+        fi
+        echo "test_result=$RESULT" >> "$GITHUB_OUTPUT"
+        {
+          echo "### 🧪 Integration Tests"
+          echo ""
+          echo "- Service: \`${DEPLOYMENT}\`"
+          echo "- Result: \`${RESULT}\`"
+          echo "- Cluster state at start: \`${CLUSTER_STATE}\`"
+          if [ "$RESULT" = "pass-advisory" ]; then
+            echo "- ⚠️ A dependency was unhealthy at probe time; the pass may not be fully authoritative (label \`ci/cluster-was-contaminated\`)."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+        # Re-surface the real test outcome as this action's exit code.
+        [ "$TESTS_OUTCOME" = "success" ]
+      env:
+        TESTS_OUTCOME: ${{ steps.tests.outcome }}
+        CLUSTER_STATE: ${{ steps.health.outputs.cluster_state }}
+        DEPLOYMENT: ${{ inputs.deployment_name }}
+        ARTIFACT_URL: ${{ steps.report.outputs.artifact-url }}

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -20,8 +20,9 @@
 name: 'Integration Test (acceptance suite vs gateway)'
 description: >-
   Verify the deployed digest is still running, run an advisory cross-service health probe,
-  pull acceptance-test secrets from Key Vault (masked), and run the service's acceptance-test
-  Maven module against the gateway with retry-on-flake.
+  pull acceptance-test secrets from Key Vault (masked), mint entitled and no-data-access
+  federated tokens, and run the service's acceptance-test Maven module against the gateway
+  with retry-on-flake.
 
 inputs:
   azure_client_id:
@@ -69,6 +70,19 @@ inputs:
       raw token as the env var named by root_token_env (default ROOT_USER_TOKEN), masked. OSDU acceptance suites
       (TestTokenUtils) consume that token directly and skip the client_credentials OIDC flow. Leave empty to use
       the suite's own OIDC flow via secret_map instead.
+    required: false
+    default: ''
+  no_data_access_client_id:
+    description: >-
+      Client ID of the shared no-entitlements UAMI created by spi onboard for services that opt in
+      to negative-authorization tests. Used only when no_data_access_token_env is set.
+    required: false
+    default: ''
+  no_data_access_token_env:
+    description: >-
+      Env var that receives the short-lived no-data-access bearer token. Empty disables the second
+      token exchange. Most services use NO_DATA_ACCESS_TESTER_ACCESS_TOKEN; Workflow uses
+      NO_ACCESS_USER_TOKEN.
     required: false
     default: ''
   root_token_env:
@@ -149,11 +163,11 @@ runs:
         fi
         SELECTOR=$(kubectl get deployment "$DEPLOYMENT" -n "$NS" \
           -o go-template='{{range $k,$v := .spec.selector.matchLabels}}{{$k}}={{$v}},{{end}}' | sed 's/,$//')
-        CURRENT=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
-          | jq -r --arg c "$CONTAINER" '[.items[].status.containerStatuses[]? | select(.name==$c) | .imageID] | .[0] // ""')
-        CURRENT_DIGEST="${CURRENT##*@}"
-        if [ "$CURRENT_DIGEST" != "$EXPECTED" ]; then
-          echo "::error::Pod is running '${CURRENT_DIGEST:-<none>}' but deploy set '$EXPECTED'. Possible Flux resume, pod restart with stale image, or cross-service overwrite."
+        CURRENT_DIGESTS=$(kubectl get pods -n "$NS" -l "$SELECTOR" -o json \
+          | jq -r --arg c "$CONTAINER" '.items[] | select(.metadata.deletionTimestamp == null and .status.phase == "Running") | .status.containerStatuses[]? | select(.name==$c and .ready==true) | .imageID | split("@")[-1]' \
+          | sort -u)
+        if ! grep -Fxq "$EXPECTED" <<< "$CURRENT_DIGESTS"; then
+          echo "::error::No ready, non-terminating pod is running '$EXPECTED'. Observed: ${CURRENT_DIGESTS:-<none>}. Possible Flux resume, pod restart with a stale image, or cross-service overwrite."
           exit 1
         fi
         echo "Verified pod is running the expected digest: $EXPECTED"
@@ -257,6 +271,96 @@ runs:
       env:
         KV: ${{ inputs.keyvault_name }}
         MAP: ${{ inputs.secret_map }}
+
+    - name: 'Mint no-data-access token (isolated OIDC login)'
+      if: ${{ inputs.no_data_access_token_env != '' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "$NO_DATA_ACCESS_CLIENT_ID" ]; then
+          echo "::error::no_data_access_client_id is required when no_data_access_token_env is set."
+          exit 1
+        fi
+        if [ -z "$AAD_CLIENT_ID" ]; then
+          echo "::error::aad_client_id is required when no_data_access_token_env is set."
+          exit 1
+        fi
+        if ! [[ "$NO_DATA_ACCESS_TOKEN_ENV" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+          echo "::error::Invalid no_data_access_token_env '$NO_DATA_ACCESS_TOKEN_ENV'."
+          exit 1
+        fi
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+          echo "::error::GitHub OIDC request variables are unavailable. The job needs id-token: write."
+          exit 1
+        fi
+
+        OIDC_TOKEN=$(curl --fail-with-body --silent --show-error \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api%3A%2F%2FAzureADTokenExchange" \
+          | jq -er '.value')
+        echo "::add-mask::$OIDC_TOKEN"
+
+        TEMP_AZURE_CONFIG=$(mktemp -d)
+        cleanup() {
+          rm -r -- "$TEMP_AZURE_CONFIG"
+        }
+        trap cleanup EXIT
+
+        LOGIN_OK=false
+        for attempt in 1 2 3; do
+          if AZURE_CONFIG_DIR="$TEMP_AZURE_CONFIG" az login \
+            --service-principal \
+            --username "$NO_DATA_ACCESS_CLIENT_ID" \
+            --tenant "$AZURE_TENANT_ID" \
+            --federated-token "$OIDC_TOKEN" \
+            --allow-no-subscriptions \
+            --output none \
+            --only-show-errors; then
+            LOGIN_OK=true
+            break
+          fi
+          echo "::warning::No-data-access OIDC login attempt $attempt failed; retrying."
+          if [ "$attempt" -lt 3 ]; then
+            sleep $((attempt * 10))
+          fi
+        done
+        if [ "$LOGIN_OK" != "true" ]; then
+          echo "::error::Failed to authenticate the shared no-data-access identity."
+          exit 1
+        fi
+
+        TOKEN=""
+        for attempt in 1 2 3; do
+          TOKEN=$(AZURE_CONFIG_DIR="$TEMP_AZURE_CONFIG" az account get-access-token \
+            --resource "$AAD_CLIENT_ID" \
+            --query accessToken \
+            --output tsv \
+            --only-show-errors || true)
+          if [ -n "$TOKEN" ]; then
+            break
+          fi
+          echo "::warning::No-data-access token attempt $attempt failed; retrying."
+          if [ "$attempt" -lt 3 ]; then
+            sleep $((attempt * 5))
+          fi
+        done
+        if [ -z "$TOKEN" ]; then
+          echo "::error::Failed to mint the no-data-access token for resource '$AAD_CLIENT_ID'."
+          exit 1
+        fi
+
+        echo "::add-mask::$TOKEN"
+        {
+          printf '%s<<__TOKEN_EOF__\n' "$NO_DATA_ACCESS_TOKEN_ENV"
+          printf '%s\n' "$TOKEN"
+          printf '__TOKEN_EOF__\n'
+        } >> "$GITHUB_ENV"
+        echo "Minted $NO_DATA_ACCESS_TOKEN_ENV as the shared no-entitlements identity."
+      env:
+        AAD_CLIENT_ID: ${{ inputs.aad_client_id }}
+        AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+        NO_DATA_ACCESS_CLIENT_ID: ${{ inputs.no_data_access_client_id }}
+        NO_DATA_ACCESS_TOKEN_ENV: ${{ inputs.no_data_access_token_env }}
 
     - name: 'Run acceptance tests (retry on flake)'
       id: tests

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -58,8 +58,27 @@ inputs:
     description: 'Key Vault holding acceptance-test secrets (org variable KEYVAULT_NAME).'
     required: true
   secret_map:
-    description: 'JSON map of env-var-name -> kv-secret-name, e.g. {"INTEGRATION_TESTER":"integration-tester-id"}. Per-service.'
-    required: true
+    description: 'JSON map of env-var-name -> kv-secret-name, e.g. {"INTEGRATION_TESTER":"integration-tester-id"}. Per-service. Empty {} when the suite needs no KV secrets (e.g. a service that authorizes any AAD service-principal token).'
+    required: false
+    default: '{}'
+  aad_client_id:
+    description: >-
+      Optional Entra app id to mint an app-only ROOT_USER_TOKEN for (org/service variable AAD_CLIENT_ID).
+      When set, the action runs `az account get-access-token --resource <aad_client_id>` AS THE CI federated
+      identity (no secret -- the GitHub-Actions port of ADME's GenerateTokenWithoutSecret.yml) and exports the
+      raw token as the env var named by root_token_env (default ROOT_USER_TOKEN), masked. OSDU acceptance suites
+      (TestTokenUtils) consume that token directly and skip the client_credentials OIDC flow. Leave empty to use
+      the suite's own OIDC flow via secret_map instead.
+    required: false
+    default: ''
+  root_token_env:
+    description: 'Env var name the acceptance suite reads a pre-minted bearer token from (raw, no "Bearer " prefix; the suite adds it). Only used when aad_client_id is set.'
+    required: false
+    default: 'ROOT_USER_TOKEN'
+  env_map:
+    description: 'Optional JSON map of NON-SECRET env-var-name -> literal value to export to the test run, e.g. {"PARTITION_BASE_URL":"https://gw/","MY_TENANT":"opendes"}. Per-service; never logged-masked (use secret_map for secrets).'
+    required: false
+    default: '{}'
   expected_digest:
     description: 'sha256 digest the deploy job set (needs.deploy.outputs.deployed_digest). The pod image is re-read and the run fails on mismatch (mid-test Flux resume / stale restart guard).'
     required: true
@@ -165,6 +184,48 @@ runs:
       env:
         DEPS: ${{ inputs.dependencies }}
         GW: ${{ inputs.gateway_url }}
+
+    - name: 'Mint ROOT_USER_TOKEN (no secret) + inject non-secret env'
+      shell: bash
+      # GitHub-Actions port of ADME's GenerateTokenWithoutSecret.yml: mint an app-only token AS the CI
+      # federated identity (azure/login already ran) and hand it to the suite as ROOT_USER_TOKEN, so the
+      # suite skips its client_credentials OIDC flow. This keeps the stack managed-identity-only -- no test
+      # service-principal secret. The token's aud=<aad_client_id> matches the istio RequestAuthentication
+      # audience + the Spring AAD filter; an app-only token (no upn/unique_name, iss=sts.windows.net) is
+      # authorized as a service principal by services that trust AAD SPs (e.g. partition's domain-admin check).
+      # env_map carries NON-SECRET config (e.g. PARTITION_BASE_URL, MY_TENANT) the suite reads from the env.
+      run: |
+        if [ -n "$AAD_CLIENT_ID" ]; then
+          TOKEN=$(az account get-access-token --resource "$AAD_CLIENT_ID" --query accessToken -o tsv)
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Failed to mint app-only token for resource '$AAD_CLIENT_ID' as the CI identity."
+            exit 1
+          fi
+          # Mask BEFORE writing to GITHUB_ENV so the token never appears in logs. Raw token only --
+          # the OSDU suite (TestTokenUtils) prepends 'Bearer ' itself.
+          echo "::add-mask::$TOKEN"
+          {
+            printf '%s<<__TOKEN_EOF__\n' "$ROOT_TOKEN_ENV"
+            printf '%s\n' "$TOKEN"
+            printf '__TOKEN_EOF__\n'
+          } >> "$GITHUB_ENV"
+          echo "Minted '$ROOT_TOKEN_ENV' (app-only, aud=$AAD_CLIENT_ID) as the CI identity."
+        fi
+        if [ -n "$ENV_MAP" ] && [ "$ENV_MAP" != "{}" ]; then
+          for env_name in $(jq -r 'keys[]' <<< "$ENV_MAP"); do
+            value=$(jq -r --arg k "$env_name" '.[$k]' <<< "$ENV_MAP")
+            {
+              printf '%s<<__ENV_EOF__\n' "$env_name"
+              printf '%s\n' "$value"
+              printf '__ENV_EOF__\n'
+            } >> "$GITHUB_ENV"
+            echo "Exported non-secret env: $env_name"
+          done
+        fi
+      env:
+        AAD_CLIENT_ID: ${{ inputs.aad_client_id }}
+        ROOT_TOKEN_ENV: ${{ inputs.root_token_env }}
+        ENV_MAP: ${{ inputs.env_map }}
 
     - name: 'Load acceptance-test secrets from Key Vault (masked, multiline-safe)'
       shell: bash

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -3,9 +3,9 @@
 #
 # CALLER REQUIREMENTS (composite actions cannot declare permissions or install tools):
 #   - The calling workflow job MUST set `permissions: { id-token: write, contents: read }`.
-#   - The caller MUST have already run azure/login + az aks get-credentials + kubelogin
-#     (the deploy job does this; integration-test reuses the same job's kube context only if
-#     in the same job -- when in a separate job it logs in itself; see inputs azure_*).
+#   - The caller MUST supply Azure credentials as the `azure_*` inputs. This action performs
+#     its own `azure/login` and `az aks get-credentials`, so it works in a job separate from
+#     deploy; no prior login is required.
 #   - kubectl, kubelogin, Java 17, and Maven must be available on the runner.
 #
 # ENCAPSULATION: this action takes only explicit inputs. It never reads vars.* or secrets.*
@@ -380,6 +380,15 @@ runs:
     - name: 'Run acceptance tests (retry on flake)'
       id: tests
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+      env:
+        # Passed through the environment rather than interpolated into `command`.
+        # GitHub expands ${{ }} into the script text BEFORE bash parses it, so a
+        # value containing shell metacharacters would become executable code.
+        # Reading them as shell variables keeps them data.
+        TEST_DIR: ${{ inputs.test_dir }}
+        MAVEN_PROFILE: ${{ inputs.maven_profile }}
+        MAVEN_GOAL: ${{ inputs.maven_goal }}
+        GATEWAY_URL: ${{ inputs.gateway_url }}
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}
         max_attempts: ${{ inputs.max_attempts }}
@@ -387,10 +396,17 @@ runs:
         # (e.g. PARTITION_BASE_URL derivations) pick it up; KV-sourced env vars are already
         # in GITHUB_ENV from the previous step.
         command: |
-          cd "${{ inputs.test_dir }}"
-          PROFILE_ARG=""
-          if [ -n "${{ inputs.maven_profile }}" ]; then PROFILE_ARG="-P ${{ inputs.maven_profile }}"; fi
-          GATEWAY_URL="${{ inputs.gateway_url }}" mvn --batch-mode --no-transfer-progress $PROFILE_ARG ${{ inputs.maven_goal }}
+          cd "$TEST_DIR"
+          # maven_goal is a goal list plus flags, so it is intentionally word-split;
+          # `set -f` stops the shell additionally glob-expanding any of those words.
+          set -f
+          if [ -n "$MAVEN_PROFILE" ]; then
+            set -- --batch-mode --no-transfer-progress -P "$MAVEN_PROFILE" $MAVEN_GOAL
+          else
+            set -- --batch-mode --no-transfer-progress $MAVEN_GOAL
+          fi
+          set +f
+          mvn "$@"
 
     - name: 'Summarize JUnit results'
       id: junit

--- a/.github/actions/integration-test/summarize_junit.py
+++ b/.github/actions/integration-test/summarize_junit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Aggregate Surefire and Failsafe XML reports for GitHub Actions outputs."""
+
+from __future__ import annotations
+
+import argparse
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TestMetrics:
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    duration_seconds: float = 0.0
+    report_files: int = 0
+    parse_errors: int = 0
+
+    def add(self, other: TestMetrics) -> None:
+        self.tests += other.tests
+        self.failures += other.failures
+        self.errors += other.errors
+        self.skipped += other.skipped
+        self.duration_seconds += other.duration_seconds
+        self.report_files += other.report_files
+        self.parse_errors += other.parse_errors
+
+
+def _tag(element: ET.Element) -> str:
+    return element.tag.rsplit("}", 1)[-1]
+
+
+def _attribute_metrics(element: ET.Element) -> TestMetrics:
+    return TestMetrics(
+        tests=int(element.attrib.get("tests", 0)),
+        failures=int(element.attrib.get("failures", 0)),
+        errors=int(element.attrib.get("errors", 0)),
+        skipped=int(element.attrib.get("skipped", 0))
+        + int(element.attrib.get("disabled", 0)),
+        duration_seconds=float(element.attrib.get("time", 0) or 0),
+    )
+
+
+def _parse_report(path: Path) -> TestMetrics:
+    root = ET.parse(path).getroot()
+    if _tag(root) == "testsuite":
+        metrics = _attribute_metrics(root)
+    elif _tag(root) == "testsuites" and "tests" in root.attrib:
+        metrics = _attribute_metrics(root)
+    elif _tag(root) == "testsuites":
+        metrics = TestMetrics()
+        for child in root:
+            if _tag(child) == "testsuite":
+                metrics.add(_attribute_metrics(child))
+    else:
+        return TestMetrics()
+    metrics.report_files = 1
+    return metrics
+
+
+def discover_reports(test_dir: Path) -> list[Path]:
+    reports: set[Path] = set()
+    for report_dir in ("surefire-reports", "failsafe-reports"):
+        reports.update(
+            path.resolve()
+            for path in test_dir.rglob(f"target/{report_dir}/*.xml")
+            if path.is_file()
+        )
+    return sorted(reports)
+
+
+def collect_metrics(test_dir: Path) -> TestMetrics:
+    total = TestMetrics()
+    for report in discover_reports(test_dir):
+        try:
+            total.add(_parse_report(report))
+        except (ET.ParseError, OSError, TypeError, ValueError):
+            total.parse_errors += 1
+    return total
+
+
+def format_duration(seconds: float) -> str:
+    rounded = int(round(seconds))
+    hours, remainder = divmod(rounded, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{seconds:.1f}s"
+
+
+def write_github_output(path: Path, metrics: TestMetrics) -> None:
+    values = {
+        "tests": metrics.tests,
+        "failures": metrics.failures,
+        "errors": metrics.errors,
+        "skipped": metrics.skipped,
+        "duration_seconds": f"{metrics.duration_seconds:.3f}",
+        "duration_display": format_duration(metrics.duration_seconds),
+        "report_files": metrics.report_files,
+        "parse_errors": metrics.parse_errors,
+    }
+    with path.open("a", encoding="utf-8") as stream:
+        for key, value in values.items():
+            stream.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test-dir", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path, required=True)
+    args = parser.parse_args()
+    write_github_output(args.github_output, collect_metrics(args.test_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -78,12 +78,8 @@ runs:
           # alongside coverage — the docker-build job downloads build-artifacts on PR events.
           mvn $MAVEN_CLI_OPTS clean package org.jacoco:jacoco-maven-plugin:0.8.11:report
           
-          # Generate coverage summary
-          echo "# Test Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "## Summary" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          find . -name "index.html" -path "*/target/site/jacoco/*" -exec grep -o '<tfoot>.*</tfoot>' {} \; | sed 's/<[^>]*>//g' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          python "${{ github.action_path }}/render_coverage_summary.py" \
+            --root . | tee -a "$GITHUB_STEP_SUMMARY"
         else
           # Regular build without coverage
           mvn $MAVEN_CLI_OPTS clean install

--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -88,6 +88,9 @@ runs:
         MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository"
         COMMUNITY_MAVEN_TOKEN: ${{ inputs.gitlab_token }}
         MAVEN_PROFILE: ${{ inputs.maven_profile }}
+        # CRS Conversion requires this repository-local Apache SIS database for
+        # its core tests. Other services ignore the unused environment value.
+        SIS_DATA: ${{ github.workspace }}/apachesis_setup/SIS_DATA
 
     - name: "Upload Build Artifacts"
       if: steps.check_pom.outputs.has_pom == 'true'

--- a/.github/actions/java-build/render_coverage_summary.py
+++ b/.github/actions/java-build/render_coverage_summary.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Render JaCoCo CSV reports as a compact GitHub Markdown summary."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Coverage:
+    instruction_missed: int = 0
+    instruction_covered: int = 0
+    branch_missed: int = 0
+    branch_covered: int = 0
+    line_missed: int = 0
+    line_covered: int = 0
+    method_missed: int = 0
+    method_covered: int = 0
+
+    def add(self, other: Coverage) -> None:
+        for field_name in self.__dataclass_fields__:
+            setattr(self, field_name, getattr(self, field_name) + getattr(other, field_name))
+
+
+def _read_coverage(path: Path) -> Coverage:
+    coverage = Coverage()
+    with path.open(encoding="utf-8-sig", newline="") as stream:
+        for row in csv.DictReader(stream):
+            coverage.instruction_missed += int(row["INSTRUCTION_MISSED"])
+            coverage.instruction_covered += int(row["INSTRUCTION_COVERED"])
+            coverage.branch_missed += int(row["BRANCH_MISSED"])
+            coverage.branch_covered += int(row["BRANCH_COVERED"])
+            coverage.line_missed += int(row["LINE_MISSED"])
+            coverage.line_covered += int(row["LINE_COVERED"])
+            coverage.method_missed += int(row["METHOD_MISSED"])
+            coverage.method_covered += int(row["METHOD_COVERED"])
+    return coverage
+
+
+def _format_ratio(covered: int, missed: int) -> str:
+    total = covered + missed
+    if total == 0:
+        return "n/a (0/0)"
+    return f"{covered / total:.1%} ({covered:,}/{total:,})"
+
+
+def _module_name(csv_path: Path, root: Path) -> str:
+    module_path = csv_path.parents[3]
+    try:
+        relative = module_path.resolve().relative_to(root.resolve())
+        name = relative.as_posix()
+    except ValueError:
+        name = module_path.as_posix()
+    return name.replace("|", r"\|") or "."
+
+
+def discover_reports(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("jacoco.csv")
+        if path.parent.name == "jacoco"
+        and path.parent.parent.name == "site"
+        and path.parent.parent.parent.name == "target"
+    )
+
+
+def render_summary(root: Path) -> str:
+    reports = discover_reports(root)
+    lines = ["# Test Coverage Report", ""]
+    if not reports:
+        lines.extend(["No JaCoCo CSV reports were generated.", ""])
+        return "\n".join(lines)
+
+    module_coverage: dict[str, Coverage] = {}
+    total = Coverage()
+    for report in reports:
+        name = _module_name(report, root)
+        coverage = _read_coverage(report)
+        module_coverage.setdefault(name, Coverage()).add(coverage)
+        total.add(coverage)
+
+    lines.extend(
+        [
+            "| Module | Lines | Branches | Instructions | Methods |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for name, coverage in sorted(module_coverage.items()):
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{name}`",
+                    _format_ratio(coverage.line_covered, coverage.line_missed),
+                    _format_ratio(coverage.branch_covered, coverage.branch_missed),
+                    _format_ratio(
+                        coverage.instruction_covered, coverage.instruction_missed
+                    ),
+                    _format_ratio(coverage.method_covered, coverage.method_missed),
+                ]
+            )
+            + " |"
+        )
+    lines.append(
+        "| "
+        + " | ".join(
+            [
+                "**Total**",
+                _format_ratio(total.line_covered, total.line_missed),
+                _format_ratio(total.branch_covered, total.branch_missed),
+                _format_ratio(total.instruction_covered, total.instruction_missed),
+                _format_ratio(total.method_covered, total.method_missed),
+            ]
+        )
+        + " |"
+    )
+    lines.extend(["", f"_Generated from {len(reports)} JaCoCo CSV report(s)._", ""])
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    print(render_summary(args.root), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/settings-apply/check-required-variables.sh
+++ b/.github/scripts/settings-apply/check-required-variables.sh
@@ -35,7 +35,9 @@ export GH_TOKEN="${GH_TOKEN:-}"
 ISSUE_TITLE="⚙️ Deploy onboarding: required CI configuration missing"
 
 secret_names="$(gh api --paginate "repos/${REPO}/actions/secrets" --jq '.secrets[].name' 2>/dev/null || echo "")"
-variable_names="$(gh api --paginate "repos/${REPO}/actions/variables" --jq '.variables[].name' 2>/dev/null || echo "")"
+variables_json="$(gh api --paginate --slurp "repos/${REPO}/actions/variables?per_page=100" 2>/dev/null || echo '[{"variables":[]}]')"
+variable_names="$(jq -r '.[].variables[].name' <<< "$variables_json")"
+no_data_token_env="$(jq -r '[.[].variables[] | select(.name == "NO_DATA_ACCESS_TOKEN_ENV") | .value][0] // ""' <<< "$variables_json")"
 
 missing=()
 have_secret() { grep -qx "$1" <<< "$secret_names"; }
@@ -45,6 +47,10 @@ have_secret "AZURE_CLIENT_ID" || missing+=("secret \`AZURE_CLIENT_ID\` — set b
 for v in K8S_DEPLOYMENT_NAME K8S_CONTAINER_NAME; do
   have_var "$v" || missing+=("variable \`$v\` — set by \`spi onboard\`")
 done
+if [[ -n "$no_data_token_env" ]]; then
+  have_var "NO_DATA_ACCESS_TESTER_CLIENT_ID" \
+    || missing+=("variable \`NO_DATA_ACCESS_TESTER_CLIENT_ID\` — set by \`spi onboard\` for negative-authorization tests")
+fi
 for v in ACCEPTANCE_TEST_DIR ACCEPTANCE_TEST_SECRET_MAP ACCEPTANCE_TEST_DEPENDENCIES; do
   have_var "$v" || missing+=("variable \`$v\` — set by the operator")
 done

--- a/.github/scripts/settings-apply/setup-rulesets.sh
+++ b/.github/scripts/settings-apply/setup-rulesets.sh
@@ -66,11 +66,17 @@ deploy_ready() {
   local ready=true name
   local secret_names variable_names
   secret_names="$(gh api --paginate "repos/${REPO_FULL_NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null || echo "")"
-  variable_names="$(gh api --paginate "repos/${REPO_FULL_NAME}/actions/variables" --jq '.variables[].name' 2>/dev/null || echo "")"
+  local variables_json no_data_token_env
+  variables_json="$(gh api --paginate --slurp "repos/${REPO_FULL_NAME}/actions/variables?per_page=100" 2>/dev/null || echo '[{"variables":[]}]')"
+  variable_names="$(jq -r '.[].variables[].name' <<< "$variables_json")"
+  no_data_token_env="$(jq -r '[.[].variables[] | select(.name == "NO_DATA_ACCESS_TOKEN_ENV") | .value][0] // ""' <<< "$variables_json")"
   grep -qx "AZURE_CLIENT_ID" <<< "$secret_names" || ready=false
   for name in ACCEPTANCE_TEST_DIR ACCEPTANCE_TEST_SECRET_MAP ACCEPTANCE_TEST_DEPENDENCIES K8S_DEPLOYMENT_NAME K8S_CONTAINER_NAME; do
     grep -qx "$name" <<< "$variable_names" || ready=false
   done
+  if [[ -n "$no_data_token_env" ]]; then
+    grep -qx "NO_DATA_ACCESS_TESTER_CLIENT_ID" <<< "$variable_names" || ready=false
+  fi
   [[ "$ready" == "true" ]]
 }
 

--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -101,6 +101,10 @@
         {
           "path": ".github/template-workflows/settings-apply.yml",
           "description": "Per-fork settings reconciliation: idempotent rulesets + required-variable check + GHCR visibility"
+        },
+        {
+          "path": ".github/template-workflows/oidc-smoke-test.yml",
+          "description": "Operator-run OIDC federated-credential smoke test (Phase 0 step 4a; branch/tag subjects)"
         }
       ],
       "template_only": [

--- a/.github/sync-config.json
+++ b/.github/sync-config.json
@@ -105,6 +105,10 @@
         {
           "path": ".github/template-workflows/oidc-smoke-test.yml",
           "description": "Operator-run OIDC federated-credential smoke test (Phase 0 step 4a; branch/tag subjects)"
+        },
+        {
+          "path": ".github/template-workflows/restore-deployment.yml",
+          "description": "Operator break-glass rollback of a service Deployment to a previous-good digest (ADR-032 §8.9)"
         }
       ],
       "template_only": [

--- a/.github/template-workflows/build.yml
+++ b/.github/template-workflows/build.yml
@@ -93,6 +93,9 @@ jobs:
         uses: ./.github/actions/java-build
         with:
           gitlab_token: ${{ secrets.GITLAB_TOKEN }}
+          # Match validate.yml so service-specific provider scopes are honored
+          # consistently in both required and feature-branch builds.
+          maven_profile: ${{ vars.MAVEN_PROFILE || 'core,azure' }}
 
   code-coverage:
     name: "📊 Code Coverage"
@@ -122,13 +125,23 @@ jobs:
         env:
           MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository"
           COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          MAVEN_PROFILE: ${{ vars.MAVEN_PROFILE || 'core,azure' }}
         run: |
           # Set up Maven CLI options
-          MAVEN_CLI_OPTS="--batch-mode -Drevision=${GITHUB_REF_NAME}-SNAPSHOT"
+          SAFE_REF="${GITHUB_REF_NAME//\//-}"
+          MAVEN_CLI_OPTS="--batch-mode -Drevision=${SAFE_REF}-SNAPSHOT"
           
           # Add settings file if it exists
           if [ -f ".mvn/community-maven.settings.xml" ]; then
             MAVEN_CLI_OPTS="$MAVEN_CLI_OPTS --settings=.mvn/community-maven.settings.xml"
+          fi
+
+          if [ -n "${MAVEN_PROFILE:-}" ]; then
+            if [[ ! "$MAVEN_PROFILE" =~ ^[A-Za-z0-9][A-Za-z0-9._,-]*$ ]]; then
+              echo "::error::Invalid MAVEN_PROFILE '${MAVEN_PROFILE}'"
+              exit 1
+            fi
+            MAVEN_CLI_OPTS="$MAVEN_CLI_OPTS -P $MAVEN_PROFILE"
           fi
           
           mvn $MAVEN_CLI_OPTS clean test org.jacoco:jacoco-maven-plugin:0.8.11:report

--- a/.github/template-workflows/build.yml
+++ b/.github/template-workflows/build.yml
@@ -132,11 +132,8 @@ jobs:
           fi
           
           mvn $MAVEN_CLI_OPTS clean test org.jacoco:jacoco-maven-plugin:0.8.11:report
-          echo "# Test Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "## Summary" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          find . -name "index.html" -path "*/target/site/jacoco/*" -exec grep -o '<tfoot>.*</tfoot>' {} \; | sed 's/<[^>]*>//g' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          python .github/actions/java-build/render_coverage_summary.py \
+            --root . | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: "Upload Coverage Report"
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0

--- a/.github/template-workflows/build.yml
+++ b/.github/template-workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
           MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository"
           COMMUNITY_MAVEN_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           MAVEN_PROFILE: ${{ vars.MAVEN_PROFILE || 'core,azure' }}
+          SIS_DATA: ${{ github.workspace }}/apachesis_setup/SIS_DATA
         run: |
           # Set up Maven CLI options
           SAFE_REF="${GITHUB_REF_NAME//\//-}"

--- a/.github/template-workflows/dependabot-validation.yml
+++ b/.github/template-workflows/dependabot-validation.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           generate_coverage: true
           gitlab_token: ${{ secrets.GITLAB_TOKEN }}
+          maven_profile: ${{ vars.MAVEN_PROFILE || 'core,azure' }}
       
       - name: "Post Build Status Comment"
         uses: ./.github/actions/pr-status

--- a/.github/template-workflows/oidc-smoke-test.yml
+++ b/.github/template-workflows/oidc-smoke-test.yml
@@ -1,0 +1,135 @@
+name: OIDC Smoke Test
+
+# Validates federated credential for branch + tag subjects against the dispatched ref.
+# Does NOT validate pull_request subject — that's exercised by validate.yml on a real PR (W5b).
+# Run this after any federated-credential edit, or to debug 'azure/login fails on branch Y' /
+# 'fails on tag Z' issues. Phase 0 step 4a uses this workflow.
+#
+# Scope: workflow_dispatch only — no push/pull_request triggers.
+# This is an operator-run tool, not CI. A workflow_dispatch trigger always presents one of the
+# branch/tag claim shapes (repo:org/repo:ref:refs/heads/<branch> or
+# repo:org/repo:ref:refs/tags/<tag>), regardless of the ref input value. The pull_request
+# subject (repo:org/repo:pull_request) is never exercised by this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: >
+          Git ref being validated (branch name or tag name, e.g. 'main' or 'v1.0.0').
+          NOTE: This input is for operator reference only — it does NOT control which ref
+          the workflow runs on or which OIDC subject claim is presented to Azure. The OIDC
+          subject is determined by the branch/tag you select in the GitHub UI 'Run workflow'
+          dropdown. Dispatch this workflow from the matching branch/tag so the OIDC subject
+          claim aligns with your federated-credential subject configuration.
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  oidc-smoke-test:
+    name: "🔐 OIDC Federated Credential Smoke Test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Preflight — verify required secrets and variables"
+        env:
+          SECRET_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          SECRET_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          SECRET_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          VAR_AKS_RESOURCE_GROUP: ${{ vars.AKS_RESOURCE_GROUP }}
+          VAR_AKS_CLUSTER_NAME: ${{ vars.AKS_CLUSTER_NAME }}
+          VAR_AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          VAR_AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+        run: |
+          missing=0
+
+          if [ -z "$SECRET_CLIENT_ID" ]; then
+            echo "::error::Required secret AZURE_CLIENT_ID is not set."
+            missing=1
+          fi
+          if [ -z "$SECRET_TENANT_ID" ]; then
+            echo "::error::Required secret AZURE_TENANT_ID is not set."
+            missing=1
+          fi
+          if [ -z "$SECRET_SUBSCRIPTION_ID" ]; then
+            echo "::error::Required secret AZURE_SUBSCRIPTION_ID is not set."
+            missing=1
+          fi
+          if [ -z "$VAR_AKS_RESOURCE_GROUP" ]; then
+            echo "::error::Required variable AKS_RESOURCE_GROUP is not set."
+            missing=1
+          fi
+          if [ -z "$VAR_AKS_CLUSTER_NAME" ]; then
+            echo "::error::Required variable AKS_CLUSTER_NAME is not set."
+            missing=1
+          fi
+
+          if [ -z "$VAR_AZURE_CLIENT_ID" ]; then
+            echo "::warning::Recommended variable AZURE_CLIENT_ID is not set — login-failure diagnostics will show a placeholder."
+          fi
+          if [ -z "$VAR_AZURE_TENANT_ID" ]; then
+            echo "::warning::Recommended variable AZURE_TENANT_ID is not set — login-failure diagnostics will show a placeholder."
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::One or more required secrets/variables are missing. Configure them before re-running."
+            exit 1
+          fi
+
+      - name: "Compute expected OIDC subject claim"
+        id: subject
+        run: |
+          # The OIDC subject claim is derived from the ref this workflow was dispatched on
+          # (github.ref), not from inputs.ref.
+          # Claim shapes produced by workflow_dispatch:
+          #   branch: repo:<owner>/<repo>:ref:refs/heads/<branch>
+          #   tag:    repo:<owner>/<repo>:ref:refs/tags/<tag>
+          EXPECTED_SUBJECT="repo:${{ github.repository }}:ref:${{ github.ref }}"
+          echo "subject=${EXPECTED_SUBJECT}" >> "$GITHUB_OUTPUT"
+          echo "Expected OIDC subject: ${EXPECTED_SUBJECT}"
+
+      - name: "Azure Login (OIDC federated credential)"
+        id: az_login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2.3.0
+        with:
+          # Use the SAME secret inputs the deploy workflow (aks-deploy) uses, so this smoke test
+          # exercises the real federated-credential path — the onboarding contract writes these as
+          # secrets. The failure-guidance step below prints the *variable* copy of the client-id for
+          # operator diagnostics, since secrets are masked in logs (design §6.1 sets AZURE_CLIENT_ID
+          # as both a secret and a variable).
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: "On login failure — print subject claim guidance"
+        if: failure() && steps.az_login.outcome == 'failure'
+        run: |
+          echo "::error::azure/login failed for subject: ${{ steps.subject.outputs.subject }}"
+          echo "::error::Verify that a federated credential with exactly this subject exists on"
+          echo "::error::the user-assigned managed identity (client-id '${{ vars.AZURE_CLIENT_ID || '<AZURE_CLIENT_ID variable not set>' }}')"
+          echo "::error::in tenant '${{ vars.AZURE_TENANT_ID || '<AZURE_TENANT_ID variable not set>' }}'."
+          echo "::error::If you just changed federated credentials, wait ~30 s and retry."
+          echo "::error::To add a missing credential:"
+          echo "::error::  az identity federated-credential create ... --subject '${{ steps.subject.outputs.subject }}'"
+
+      - name: "Get AKS credentials (Entra-only cluster — convert kubeconfig via kubelogin)"
+        run: |
+          # The shared cluster runs with disableLocalAccounts=true + Azure RBAC (Phase 0 gate 0b),
+          # so a plain kubeconfig cannot authenticate non-interactively. Install kubelogin (and
+          # kubectl) and convert the kubeconfig to reuse the azure/login federated identity —
+          # otherwise kubectl would hang on an interactive device-code prompt in CI.
+          az aks install-cli
+          az aks get-credentials \
+            --resource-group "${{ vars.AKS_RESOURCE_GROUP }}" \
+            --name "${{ vars.AKS_CLUSTER_NAME }}" \
+            --overwrite-existing
+          kubelogin convert-kubeconfig -l azurecli
+
+      - name: "Verify service namespace is reachable"
+        run: |
+          NS="${{ vars.K8S_NAMESPACE }}"
+          kubectl get deployments -n "${NS:-osdu}"

--- a/.github/template-workflows/restore-deployment.yml
+++ b/.github/template-workflows/restore-deployment.yml
@@ -1,0 +1,116 @@
+# Manually roll a service's Deployment back to a previous-good image digest.
+#
+# Operator break-glass for §8.9: when one bad deploy is poisoning cross-service tests, restore
+# the service to its last-known-good digest without waiting for the original PR author to push
+# a fix. Human-triggered only -- there is NO auto-rollback (NG5 stands).
+#
+# Reads the previous-good digest from a prior deploy run's `aks-deploy` `previous_digest` output
+# (operators copy it from that run's logs/summary). The image already exists in GHCR, so this
+# skips docker-build entirely and just re-points the Deployment.
+#
+# Single-service workflow: the target service is read from `vars.SERVICE_NAME`, NOT a dispatch
+# input. Each fork hosts exactly one service; taking `service` as an input would let an operator
+# dispatch `service=storage` in the partition fork and deploy the wrong image into partition's
+# Deployment.
+#
+# Reference: design doc §8.9 + §5.2 (aks-deploy contract). Blocked from merge until W3
+# (.github/actions/aks-deploy) lands -- this workflow `uses:` that action.
+
+name: Restore Deployment
+
+run-name: "restore ${{ vars.SERVICE_NAME }} -> ${{ inputs.digest }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      digest:
+        description: 'Previous-good image digest to restore (must start with sha256:, e.g. sha256:abc123...). Copy it from a prior deploy run''s aks-deploy previous_digest output.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # Per-service group, identical to the deploy job's, so a restore cannot race an in-flight
+  # PR deploy for the same service. cancel-in-progress: false -- never abandon a rollout midway.
+  group: spi-stack-${{ vars.SERVICE_NAME }}
+  cancel-in-progress: false
+
+jobs:
+  restore:
+    name: "Restore deployment"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Pre-flight: SERVICE_NAME must be set"
+        shell: bash
+        # Catches forks where onboarding has not completed -- without SERVICE_NAME the image
+        # reference and concurrency group are wrong.
+        run: |
+          if [ -z "$SERVICE_NAME" ]; then
+            echo "::error::vars.SERVICE_NAME is not set on this repo. Set it (gh variable set SERVICE_NAME=<name>) or complete onboarding before restoring."
+            exit 1
+          fi
+          echo "Target service: $SERVICE_NAME"
+        env:
+          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+
+      - name: "Validate digest format"
+        shell: bash
+        # Catches the "double sha256:" foot-gun and typos before kubectl ever runs.
+        run: |
+          if ! printf '%s' "$DIGEST" | grep -Eq '^sha256:[a-f0-9]{64}$'; then
+            echo "::error::digest must match ^sha256:[a-f0-9]{64}$ (got: '$DIGEST')."
+            exit 1
+          fi
+        env:
+          DIGEST: ${{ inputs.digest }}
+
+      - name: "Checkout (for the aks-deploy composite action)"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: "Install kubectl"
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+
+      - name: "Install kubelogin"
+        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29  # v1.3
+        with:
+          kubelogin-version: 'v0.1.4'
+
+      - name: "Restore image (by digest)"
+        uses: ./.github/actions/aks-deploy
+        with:
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          aks_resource_group: ${{ vars.AKS_RESOURCE_GROUP }}
+          aks_cluster_name: ${{ vars.AKS_CLUSTER_NAME }}
+          namespace: ${{ vars.K8S_NAMESPACE }}
+          flux_namespace: ${{ vars.FLUX_NAMESPACE }}
+          deployment_name: ${{ vars.K8S_DEPLOYMENT_NAME }}
+          container_name: ${{ vars.K8S_CONTAINER_NAME }}
+          image_repository: ghcr.io/${{ github.repository_owner }}/${{ vars.SERVICE_NAME }}
+          image_digest: ${{ inputs.digest }}
+        id: restore
+
+      - name: "Audit summary"
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### ♻️ Restore Deployment"
+            echo ""
+            echo "- Triggered by: \`${{ github.actor }}\`"
+            echo "- Service: \`${SERVICE_NAME}\` (from vars.SERVICE_NAME)"
+            echo "- Deployment: \`${DEPLOYMENT}\`"
+            echo "- Restored to digest: \`${DIGEST}\`"
+            echo "- aks-deploy previous_digest: \`${PREV:-<none>}\`"
+            echo "- aks-deploy deployed_digest: \`${DEPLOYED:-<none>}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+          DEPLOYMENT: ${{ vars.K8S_DEPLOYMENT_NAME }}
+          DIGEST: ${{ inputs.digest }}
+          PREV: ${{ steps.restore.outputs.previous_digest }}
+          DEPLOYED: ${{ steps.restore.outputs.deployed_digest }}

--- a/.github/template-workflows/restore-deployment.yml
+++ b/.github/template-workflows/restore-deployment.yml
@@ -76,7 +76,7 @@ jobs:
           DIGEST: ${{ inputs.digest }}
 
       - name: "Checkout (for the aks-deploy composite action)"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: "Install kubectl"
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0

--- a/.github/template-workflows/restore-deployment.yml
+++ b/.github/template-workflows/restore-deployment.yml
@@ -8,7 +8,8 @@
 # (operators copy it from that run's logs/summary). The image already exists in GHCR, so this
 # skips docker-build entirely and just re-points the Deployment.
 #
-# Single-service workflow: the target service is read from `vars.SERVICE_NAME`, NOT a dispatch
+# Single-service workflow: the target service is resolved from `vars.SERVICE_NAME`, falling back
+# to this repository's own name (the same derivation validate.yml uses), NOT a dispatch
 # input. Each fork hosts exactly one service; taking `service` as an input would let an operator
 # dispatch `service=storage` in the partition fork and deploy the wrong image into partition's
 # Deployment.
@@ -18,7 +19,7 @@
 
 name: Restore Deployment
 
-run-name: "restore ${{ vars.SERVICE_NAME }} -> ${{ inputs.digest }}"
+run-name: "restore ${{ vars.SERVICE_NAME || github.event.repository.name }} -> ${{ inputs.digest }}"
 
 on:
   workflow_dispatch:
@@ -45,18 +46,23 @@ jobs:
     name: "Restore deployment"
     runs-on: ubuntu-latest
     steps:
-      - name: "Pre-flight: SERVICE_NAME must be set"
+      - name: "Pre-flight: resolve the target service"
         shell: bash
-        # Catches forks where onboarding has not completed -- without SERVICE_NAME the image
-        # reference and concurrency group are wrong.
+        # SERVICE_NAME is optional everywhere else in this template: validate.yml derives the
+        # image name, jar path and concurrency group as `vars.SERVICE_NAME ||
+        # github.event.repository.name`. Hard-requiring it here made restore unusable on a
+        # fully-onboarded fork that relies on that fallback, which is precisely when an
+        # operator needs break-glass. Use the same fallback. It stays safe because the value
+        # is still derived from THIS repository rather than from operator input, so a restore
+        # can never target another fork's Deployment.
         run: |
           if [ -z "$SERVICE_NAME" ]; then
-            echo "::error::vars.SERVICE_NAME is not set on this repo. Set it (gh variable set SERVICE_NAME=<name>) or complete onboarding before restoring."
+            echo "::error::Could not resolve a target service: vars.SERVICE_NAME is unset and the repository name is empty."
             exit 1
           fi
           echo "Target service: $SERVICE_NAME"
         env:
-          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+          SERVICE_NAME: ${{ vars.SERVICE_NAME || github.event.repository.name }}
 
       - name: "Validate digest format"
         shell: bash
@@ -91,7 +97,7 @@ jobs:
         run: ./.github/actions/docker-build/compute-metadata.sh ghcr.io "$OWNER" "$SERVICE_NAME"
         env:
           OWNER: ${{ github.repository_owner }}
-          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+          SERVICE_NAME: ${{ vars.SERVICE_NAME || github.event.repository.name }}
 
       - name: "Restore image (by digest)"
         uses: ./.github/actions/aks-deploy
@@ -117,14 +123,14 @@ jobs:
             echo "### ♻️ Restore Deployment"
             echo ""
             echo "- Triggered by: \`${{ github.actor }}\`"
-            echo "- Service: \`${SERVICE_NAME}\` (from vars.SERVICE_NAME)"
+            echo "- Service: \`${SERVICE_NAME}\`"
             echo "- Deployment: \`${DEPLOYMENT}\`"
             echo "- Restored to digest: \`${DIGEST}\`"
             echo "- aks-deploy previous_digest: \`${PREV:-<none>}\`"
             echo "- aks-deploy deployed_digest: \`${DEPLOYED:-<none>}\`"
           } >> "$GITHUB_STEP_SUMMARY"
         env:
-          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+          SERVICE_NAME: ${{ vars.SERVICE_NAME || github.event.repository.name }}
           DEPLOYMENT: ${{ vars.K8S_DEPLOYMENT_NAME }}
           DIGEST: ${{ inputs.digest }}
           PREV: ${{ steps.restore.outputs.previous_digest }}

--- a/.github/template-workflows/restore-deployment.yml
+++ b/.github/template-workflows/restore-deployment.yml
@@ -34,8 +34,10 @@ permissions:
 
 concurrency:
   # Per-service group, identical to the deploy job's, so a restore cannot race an in-flight
-  # PR deploy for the same service. cancel-in-progress: false -- never abandon a rollout midway.
-  group: spi-stack-${{ vars.SERVICE_NAME }}
+  # PR deploy for the same service. The fallback must match validate.yml's deploy job
+  # exactly, otherwise an unset SERVICE_NAME yields a different group and the two would
+  # not actually share a lock. cancel-in-progress: false -- never abandon a rollout midway.
+  group: spi-stack-${{ vars.SERVICE_NAME || github.event.repository.name }}
   cancel-in-progress: false
 
 jobs:
@@ -78,6 +80,19 @@ jobs:
         with:
           kubelogin-version: 'v0.1.4'
 
+      - name: "Compute image repository"
+        id: image
+        shell: bash
+        # Reuse the docker-build metadata helper so the restore path derives the GHCR
+        # repository exactly like the build path does. Critically it lowercases: GHCR
+        # rejects uppercase, and github.repository_owner preserves the org's canonical
+        # casing (e.g. "Azure"), so interpolating it raw yields an unpullable
+        # ghcr.io/Azure/<service>.
+        run: ./.github/actions/docker-build/compute-metadata.sh ghcr.io "$OWNER" "$SERVICE_NAME"
+        env:
+          OWNER: ${{ github.repository_owner }}
+          SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+
       - name: "Restore image (by digest)"
         uses: ./.github/actions/aks-deploy
         with:
@@ -90,7 +105,7 @@ jobs:
           flux_namespace: ${{ vars.FLUX_NAMESPACE }}
           deployment_name: ${{ vars.K8S_DEPLOYMENT_NAME }}
           container_name: ${{ vars.K8S_CONTAINER_NAME }}
-          image_repository: ghcr.io/${{ github.repository_owner }}/${{ vars.SERVICE_NAME }}
+          image_repository: ${{ steps.image.outputs.image_repository }}
           image_digest: ${{ inputs.digest }}
         id: restore
 

--- a/.github/template-workflows/sync-template.yml
+++ b/.github/template-workflows/sync-template.yml
@@ -490,7 +490,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           base-branch: main
           head-branch: ${{ env.SYNC_BRANCH }}
-          pr-title: "Sync template updates ${{ env.CURRENT_DATE }}"
+          pr-title: "chore: sync template updates ${{ env.CURRENT_DATE }}"
           fallback-description: ${{ env.FALLBACK_DESCRIPTION }}
           fallback-description-b64: ${{ env.FALLBACK_DESCRIPTION_B64 }}
           azure-api-key: ${{ secrets.AZURE_API_KEY }}
@@ -555,7 +555,7 @@ jobs:
 
           # Update PR title and description
           gh pr edit "$PR_NUMBER" \
-            --title "🔄 Sync template updates (Updated $(date +%Y-%m-%d))" \
+            --title "chore: sync template updates $(date +%Y-%m-%d)" \
             --body "$FALLBACK_DESCRIPTION_DECODED"
 
           # Add comment to the PR about the update

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -714,6 +714,8 @@ jobs:
           test_dir: ${{ vars.ACCEPTANCE_TEST_DIR }}
           secret_map: ${{ vars.ACCEPTANCE_TEST_SECRET_MAP || '{}' }}
           aad_client_id: ${{ vars.AAD_CLIENT_ID }}
+          no_data_access_client_id: ${{ vars.NO_DATA_ACCESS_TESTER_CLIENT_ID }}
+          no_data_access_token_env: ${{ vars.NO_DATA_ACCESS_TOKEN_ENV || '' }}
           env_map: ${{ vars.ACCEPTANCE_TEST_ENV_MAP || '{}' }}
           dependencies: ${{ vars.ACCEPTANCE_TEST_DEPENDENCIES || '{}' }}
           maven_profile: ${{ vars.MAVEN_PROFILE || '' }}

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -706,7 +706,9 @@ jobs:
           gateway_url: ${{ vars.GATEWAY_URL }}
           keyvault_name: ${{ vars.KEYVAULT_NAME }}
           test_dir: ${{ vars.ACCEPTANCE_TEST_DIR }}
-          secret_map: ${{ vars.ACCEPTANCE_TEST_SECRET_MAP }}
+          secret_map: ${{ vars.ACCEPTANCE_TEST_SECRET_MAP || '{}' }}
+          aad_client_id: ${{ vars.AAD_CLIENT_ID }}
+          env_map: ${{ vars.ACCEPTANCE_TEST_ENV_MAP || '{}' }}
           dependencies: ${{ vars.ACCEPTANCE_TEST_DEPENDENCIES || '{}' }}
           maven_profile: ${{ vars.MAVEN_PROFILE || '' }}
           expected_digest: ${{ needs.deploy.outputs.deployed_digest }}

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -55,6 +55,17 @@ on:
         required: false
         type: boolean
         default: false
+      # Declared by W13 (#9), inert until W5a/W5b reference it. Lets an operator force a full
+      # docker-push -> deploy -> integration-test run on the current HEAD even for paths-ignored
+      # events (e.g. after a template-sync PR brings workflow/action changes into a fork). The
+      # `if:` wiring lives in the docker-push job (W5a) and the deploy/integration-test jobs
+      # (W5b) -- this slot only declares the input. Run me after template-sync to verify workflow
+      # changes still pass the full pipeline.
+      force_full_pipeline:
+        description: 'Force the full docker-push + deploy + integration-test pipeline on the current HEAD (used after template-sync to verify workflow changes).'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -678,6 +678,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    # Same per-service lock as the deploy job: a run must hold the cluster from
+    # deploy through integration-test so a superseded run's deploy cannot swap the
+    # pod under a running suite. cancel-in-progress: false -- never abandon a run.
+    concurrency:
+      group: spi-stack-${{ vars.SERVICE_NAME || github.event.repository.name }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: "Set up Java"
@@ -711,4 +717,8 @@ jobs:
           env_map: ${{ vars.ACCEPTANCE_TEST_ENV_MAP || '{}' }}
           dependencies: ${{ vars.ACCEPTANCE_TEST_DEPENDENCIES || '{}' }}
           maven_profile: ${{ vars.MAVEN_PROFILE || '' }}
+          maven_goal: ${{ vars.MAVEN_GOAL || 'verify' }}
+          root_token_env: ${{ vars.ROOT_TOKEN_ENV || 'ROOT_USER_TOKEN' }}
+          timeout_minutes: ${{ vars.IT_TIMEOUT_MINUTES || '25' }}
+          max_attempts: ${{ vars.IT_MAX_ATTEMPTS || '2' }}
           expected_digest: ${{ needs.deploy.outputs.deployed_digest }}

--- a/.github/template-workflows/validate.yml
+++ b/.github/template-workflows/validate.yml
@@ -595,3 +595,118 @@ jobs:
             echo "❌ Docker build failed or was cancelled"; exit 1
           fi
           echo "✅ Docker Build checks completed successfully"
+
+  # ──────────────────────────────────────────────────────────────────────────────
+  # Deploy lane (W5b). Appended after docker-push; both jobs consume the trusted
+  # push job's digest and replicate its §5.5 trust-boundary if: (defense in depth --
+  # they also needs:[docker-push], which is itself trust-gated). The extra
+  # `vars.AZURE_CLIENT_ID != ''` conjunct makes un-onboarded forks SKIP these jobs
+  # cleanly (no red azure/login failure) until `spi onboard` has run -- onboarding
+  # writes AZURE_CLIENT_ID as both a secret and a variable for exactly this gate.
+  # ──────────────────────────────────────────────────────────────────────────────
+  deploy:
+    name: "🚀 Deploy to spi-stack"
+    needs: [check-initialization, check-repo-state, java-build, docker-push]
+    if: |
+      (
+        needs.java-build.outputs.build_result == 'success' &&
+        vars.AZURE_CLIENT_ID != '' &&
+        github.actor != 'dependabot[bot]' &&
+        github.event_name != 'pull_request_target' &&
+        github.event_name != 'workflow_dispatch' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.head.repo.full_name == github.repository)
+      ) || (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.force_full_pipeline == true &&
+        vars.AZURE_CLIENT_ID != ''
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write          # mint the OIDC token for azure/login
+      contents: read
+    # Per-service lock (not cluster-wide): two services deploy in parallel, two PRs
+    # for the SAME service queue. cancel-in-progress: false -- never abandon a rollout.
+    concurrency:
+      group: spi-stack-${{ vars.SERVICE_NAME || github.event.repository.name }}
+      cancel-in-progress: false
+    outputs:
+      previous_digest: ${{ steps.deploy.outputs.previous_digest }}
+      deployed_digest: ${{ steps.deploy.outputs.deployed_digest }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: "Install kubectl"
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+      - name: "Install kubelogin"
+        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29  # v1.3
+        with:
+          kubelogin-version: 'v0.1.4'
+      - name: "Deploy to spi-stack (by digest)"
+        id: deploy
+        uses: ./.github/actions/aks-deploy
+        with:
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          aks_resource_group: ${{ vars.AKS_RESOURCE_GROUP }}
+          aks_cluster_name: ${{ vars.AKS_CLUSTER_NAME }}
+          namespace: ${{ vars.K8S_NAMESPACE }}
+          flux_namespace: ${{ vars.FLUX_NAMESPACE }}
+          deployment_name: ${{ vars.K8S_DEPLOYMENT_NAME }}
+          container_name: ${{ vars.K8S_CONTAINER_NAME }}
+          image_repository: ${{ needs.docker-push.outputs.image_repository }}
+          image_digest: ${{ needs.docker-push.outputs.image_digest }}
+
+  integration-test:
+    name: "🧪 Integration Tests"
+    needs: [check-initialization, check-repo-state, java-build, docker-push, deploy]
+    if: |
+      (
+        needs.java-build.outputs.build_result == 'success' &&
+        vars.AZURE_CLIENT_ID != '' &&
+        github.actor != 'dependabot[bot]' &&
+        github.event_name != 'pull_request_target' &&
+        github.event_name != 'workflow_dispatch' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.head.repo.full_name == github.repository)
+      ) || (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.force_full_pipeline == true &&
+        vars.AZURE_CLIENT_ID != ''
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: "Set up Java"
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: "Install kubectl"
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d  # v5.1.0
+      - name: "Install kubelogin"
+        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29  # v1.3
+        with:
+          kubelogin-version: 'v0.1.4'
+      - name: "Run integration tests"
+        uses: ./.github/actions/integration-test
+        with:
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          aks_resource_group: ${{ vars.AKS_RESOURCE_GROUP }}
+          aks_cluster_name: ${{ vars.AKS_CLUSTER_NAME }}
+          namespace: ${{ vars.K8S_NAMESPACE }}
+          deployment_name: ${{ vars.K8S_DEPLOYMENT_NAME }}
+          container_name: ${{ vars.K8S_CONTAINER_NAME }}
+          gateway_url: ${{ vars.GATEWAY_URL }}
+          keyvault_name: ${{ vars.KEYVAULT_NAME }}
+          test_dir: ${{ vars.ACCEPTANCE_TEST_DIR }}
+          secret_map: ${{ vars.ACCEPTANCE_TEST_SECRET_MAP }}
+          dependencies: ${{ vars.ACCEPTANCE_TEST_DEPENDENCIES || '{}' }}
+          maven_profile: ${{ vars.MAVEN_PROFILE || '' }}
+          expected_digest: ${{ needs.deploy.outputs.deployed_digest }}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -18,7 +18,7 @@ jobs:
   validate:
     name: Validate Template
     runs-on: ubuntu-latest
-    if: github.repository == 'azure/osdu-spi'
+    if: github.event.repository.is_template == true
     permissions:
       contents: read
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -75,6 +75,9 @@ jobs:
             echo "Validating $file"
             jq empty "$file" && echo "✅ $file is valid" || echo "❌ $file has errors"
           done
+
+      - name: Test workflow summary helpers
+        run: python -m unittest discover -s tests -p 'test_*.py' -v
           
       - name: Check Documentation Links
         run: |

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,8 +18,15 @@ ARG JAVA_OPTS=""
 # did, so we bake the same /opt/agents/ path here. Pinned by version + sha256; bumping the version
 # requires updating the checksum (ADR-037). The agent is the arch-independent jar — no RUN, so the
 # arm64 leg stays cheap. The entrypoint attaches it only when a real connection string is set.
+# --chmod=0755 is required, and the mode applies to the auto-created /opt/agents directory too:
+# an ADD from a URL defaults to 0600 root-owned, and services run non-root (runAsUser 1000). The
+# directory needs the execute/traversal bit (0755) AND the jar needs read. With 0644 the directory
+# loses its execute bit, uid 1000 cannot traverse it, the entrypoint's `[ -f .../agent.jar ]` check
+# fails, `-javaagent` is never attached, the App Insights request-telemetry context stays null, and
+# core-lib-azure's LogCustomDimensionFilter NPEs on the first gateway request (HTTP 500). The jar's
+# execute bit is harmless (a -javaagent jar is read, never exec'd).
 ARG APPLICATIONINSIGHTS_AGENT_VERSION="3.7.8"
-ADD --checksum=sha256:e8c494f3f9a36f6b99790a4741b03f51988dc5c4244c14cc24be51874ef72e6b \
+ADD --checksum=sha256:e8c494f3f9a36f6b99790a4741b03f51988dc5c4244c14cc24be51874ef72e6b --chmod=0755 \
     https://repo1.maven.org/maven2/com/microsoft/azure/applicationinsights-agent/${APPLICATIONINSIGHTS_AGENT_VERSION}/applicationinsights-agent-${APPLICATIONINSIGHTS_AGENT_VERSION}.jar \
     /opt/agents/applicationinsights-agent.jar
 

--- a/doc/src/adr/032-cicd-deploy-loop-via-suspended-flux.md
+++ b/doc/src/adr/032-cicd-deploy-loop-via-suspended-flux.md
@@ -1,0 +1,56 @@
+# ADR-032: CI/CD Deploy Loop via Suspended Flux
+
+## Context
+
+The OSDU SPI engineering system (three-branch fork model — [ADR-001](001-three-branch-strategy.md)) produces validated Maven artifacts but no container images, deployments, or integration-test signal. The runtime infrastructure (`osdu-spi-stack`) uses Flux GitOps for initial cluster provisioning and baseline state.
+
+Two forces are in tension:
+
+- **Flux reconciliation** continuously drives cluster state toward the declared HelmRelease manifests; any image injected outside GitOps is reverted on the next reconcile cycle.
+- **Per-PR CI cadence** requires mutating live Deployments freely — once per push — without waiting for a GitOps commit round-trip or creating per-PR HelmRelease revisions.
+
+The template-workflow distribution model ([ADR-015](015-template-workflows-separation-pattern.md)) means the deploy mechanism must be expressible as a reusable GitHub Actions job pattern, not a cluster-operator workflow.
+
+There is a single shared `osdu-spi-stack` AKS cluster. Per-service "CI mode toggles" on that shared cluster are not feasible; the coexistence strategy must cover the whole cluster.
+
+## Decision
+
+Operate the shared `osdu-spi-stack` cluster with **all Flux Kustomizations permanently suspended** as the normal steady state.
+
+Key mechanics:
+
+- After initial cluster bring-up, `flux suspend kustomization --all -n flux-system` is run once and never reversed during CI operation.
+- Per-PR deploy jobs execute `kubectl set image deployment/<name> <container>=<registry>/<image>@<digest> -n osdu` directly.
+- Images are always referenced by **immutable digest** (`sha256:…`), never by mutable tag, so the running image is guaranteed to be what the build produced.
+- A pre-flight step in every deploy job asserts that all Flux Kustomizations are still suspended; the job fails fast if any are found resumed, surfacing accidental operator action immediately.
+- Flux is resumed only during a **planned baseline refresh** — a coordinated, CI-freeze outage that resets all Deployments to the declared HelmRelease state, then re-suspends Flux.
+- Deployment and container names are exposed as per-service GitHub repo variables (`K8S_DEPLOYMENT_NAME`, `K8S_CONTAINER_NAME`) rather than derived from service names, insulating CI from Helm chart naming changes.
+
+## Consequences
+
+**Positive:**
+
+- Per-PR deploy cadence is achievable with sub-minute latency — no GitOps commit round-trip.
+- Zero race conditions between CI image injection and Flux reconciliation.
+- Deploy mechanism is a single `kubectl set image` invocation; no Helm dynamics, no HelmRelease editing required in CI.
+- Pre-flight Flux assertion prevents silent drift caused by accidental Flux resume.
+- Immutable digest references prevent tag-reuse and guarantee test/run image identity.
+
+**Negative:**
+
+- Cluster state drifts progressively from the declared HelmRelease manifests after many CI runs; only a baseline refresh resets it.
+- Operators cannot rely on Flux self-healing during CI cycles (e.g., an accidental `kubectl delete deployment` is not auto-restored).
+- Baseline refresh is a planned outage requiring a CI freeze across all current service forks — not a casual cron job.
+- The "CI mode" invariant requires explicit operator awareness; documentation and the pre-flight assertion are the only enforcement mechanisms.
+
+## Alternatives Considered
+
+- **Flux image automation** (image-reflector + image-automation controllers watching the registry and updating the HelmRelease) — rejected: requires a writable GitOps commit per image push, adds reflector poll latency, and still races when two PRs build simultaneously against the same shared Deployment.
+
+- **Argo CD instead of Flux** (`argocd app set --helm-set image.tag=…`) — avoids direct `kubectl` mutation. Rejected: introduces a second GitOps tool alongside the Flux-managed baseline; the cluster is already provisioned with Flux, so the operational complexity outweighs the benefit for a shared sandbox cluster.
+
+- **Helm CI release-per-PR** (`helm upgrade --install <svc>-pr-<number> …`) — each PR installs an isolated Helm release. Rejected: requires per-PR namespace or resource segregation, complicates integration tests against the shared gateway, and leaves orphaned releases when branches are deleted without careful cleanup hooks.
+
+---
+
+[← ADR-031](031-template-sync-duplicate-prevention.md) | :material-arrow-up: [Catalog](index.md)

--- a/doc/src/adr/034-federated-identity-actions-to-azure.md
+++ b/doc/src/adr/034-federated-identity-actions-to-azure.md
@@ -1,0 +1,38 @@
+# ADR-034: Federated Identity for Actions to Azure
+
+## Context
+
+- Deploy and integration-test workflows need authenticated access to Azure (AKS + Key Vault).
+- Static `AZURE_CREDENTIALS` JSON secrets are long-lived credentials and a security risk — the same no-long-lived-credentials principle that replaced PATs with GitHub App tokens for in-repo automation ([ADR-029](029-github-app-authentication-strategy.md)).
+- CI credentials must be isolated per service fork to bound blast radius.
+
+## Decision
+
+- Provision one User-Assigned Managed Identity per service fork and authenticate GitHub Actions through OIDC (`azure/login@v2`) instead of static JSON credentials. No static secrets stored in GitHub.
+- Federated credential subjects required for the deploy/test path:
+  - `repo:${ORG}/${SERVICE}:ref:refs/heads/*` (branch-push and internal-PR deploys)
+  - `repo:${ORG}/${SERVICE}:pull_request` (internal PR events)
+- Two further subjects are **not** granted by default (least privilege) — provision each only when it is actually exercised:
+  - `repo:${ORG}/${SERVICE}:ref:refs/tags/*` — only if image push/retag moves to OIDC registry auth (the §7.4 ACR fallback). With public GHCR (ADR-033) the release re-tag uses `GITHUB_TOKEN`, so no tag-scoped Azure subject is used today.
+  - `repo:${ORG}/${SERVICE}:environment:<name>` — only if the deploy job adopts the `environment:` job key for gating.
+- Use three repo secrets as the handoff contract from onboarding to workflows — `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (`AZURE_CLIENT_ID` is also exposed as a repo variable for use in `if:` expressions and operator-facing diagnostics).
+- Keep the ~20-step onboarding automated, split on the credential boundary:
+  - **Cluster side (`osdu-spi-stack`, `spi onboard`)**: identity creation, federated credentials, AKS/KV RBAC, and the Kubernetes RoleBinding; writes the `AZURE_*` secrets to the target repo.
+  - **Fork side (`osdu-spi`, extended `init.yml`)**: GHCR visibility, ruleset setup, and per-service repository variables.
+
+## Consequences
+
+- ✅ No long-lived Azure credential material stored in GitHub.
+- ✅ Per-fork identity limits impact if one repository is compromised.
+- ✅ Credential and repository setup responsibilities are explicit and automatable.
+- ⚠️ Setup is operationally heavy without automation, so `spi onboard` + `init.yml` coordination is required.
+- ⚠️ Subject-claim mismatches (`refs/heads`, `pull_request`, `refs/tags`) cause authentication failures that are tedious to debug — the `oidc-smoke-test.yml` operator tool exists to validate each subject in isolation.
+
+## Alternatives Considered
+
+- **Keep static `AZURE_CREDENTIALS` secrets** — rejected: long-lived secrets and a larger compromise surface.
+- **One shared identity for all service forks** — rejected: poor blast-radius isolation and weaker per-service boundary control.
+
+---
+
+[← ADR-033](033-ghcr-as-service-image-registry.md) | :material-arrow-up: [Catalog](index.md)

--- a/doc/src/adr/034-federated-identity-actions-to-azure.md
+++ b/doc/src/adr/034-federated-identity-actions-to-azure.md
@@ -3,6 +3,8 @@
 ## Context
 
 - Deploy and integration-test workflows need authenticated access to Azure (AKS + Key Vault).
+- Negative authorization tests need a second valid Entra token whose caller has
+  no OSDU entitlements.
 - Static `AZURE_CREDENTIALS` JSON secrets are long-lived credentials and a security risk — the same no-long-lived-credentials principle that replaced PATs with GitHub App tokens for in-repo automation ([ADR-029](029-github-app-authentication-strategy.md)).
 - CI credentials must be isolated per service fork to bound blast radius.
 
@@ -10,12 +12,36 @@
 
 - Provision one User-Assigned Managed Identity per service fork and authenticate GitHub Actions through OIDC (`azure/login@v2`) instead of static JSON credentials. No static secrets stored in GitHub.
 - Federated credential subjects required for the deploy/test path:
-  - `repo:${ORG}/${SERVICE}:ref:refs/heads/*` (branch-push and internal-PR deploys)
+  - explicit `repo:${ORG}/${SERVICE}:ref:refs/heads/<branch>` subjects for
+    `main`, `fork_integration`, and `fork_upstream`
   - `repo:${ORG}/${SERVICE}:pull_request` (internal PR events)
 - Two further subjects are **not** granted by default (least privilege) — provision each only when it is actually exercised:
   - `repo:${ORG}/${SERVICE}:ref:refs/tags/*` — only if image push/retag moves to OIDC registry auth (the §7.4 ACR fallback). With public GHCR (ADR-033) the release re-tag uses `GITHUB_TOKEN`, so no tag-scoped Azure subject is used today.
-  - `repo:${ORG}/${SERVICE}:environment:<name>` — only if the deploy job adopts the `environment:` job key for gating.
+  - `repo:${ORG}/${SERVICE}:environment:<name>` — not currently used.
 - Use three repo secrets as the handoff contract from onboarding to workflows — `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (`AZURE_CLIENT_ID` is also exposed as a repo variable for use in `if:` expressions and operator-facing diagnostics).
+- Provision one additional UAMI named `spi-ci-no-data-access` per Stack
+  environment when the onboarded service opts into negative-authorization
+  tests. It is shared by those repositories because it deliberately has no
+  Azure RBAC and no OSDU entitlements; compromising it grants no positive data
+  or deployment access. Services without a negative-access test do not receive
+  its client ID and do not mint its token.
+- The shared identity uses the same four exact pull-request/branch subjects as
+  the service identity, but only for repositories whose active test profile
+  requires a negative caller. Azure permits at most 20 federated credentials per
+  UAMI, so this model supports five opted-in repositories before the identity
+  must be sharded or flexible federation becomes generally available.
+  `spi onboard` writes
+  `NO_DATA_ACCESS_TESTER_CLIENT_ID`, `NO_DATA_ACCESS_TESTER_PRINCIPAL_ID`,
+  `NO_DATA_ACCESS_TESTER_IDENTITY_NAME`, and `NO_DATA_ACCESS_TOKEN_ENV` as
+  non-secret repository variables only for opted-in services.
+- The integration-test action requests a fresh GitHub OIDC assertion and logs
+  the shared identity into a temporary `AZURE_CONFIG_DIR` with
+  `--allow-no-subscriptions`. It mints and masks
+  the configured token env, then removes the temporary Azure CLI state without
+  replacing the service identity's authenticated session. Partition, File,
+  Storage, Register, Secret, and EDS-DMS use
+  `NO_DATA_ACCESS_TESTER_ACCESS_TOKEN`; Workflow uses `NO_ACCESS_USER_TOKEN`,
+  matching current ADME pipelines.
 - Keep the ~20-step onboarding automated, split on the credential boundary:
   - **Cluster side (`osdu-spi-stack`, `spi onboard`)**: identity creation, federated credentials, AKS/KV RBAC, and the Kubernetes RoleBinding; writes the `AZURE_*` secrets to the target repo.
   - **Fork side (`osdu-spi`, extended `init.yml`)**: GHCR visibility, ruleset setup, and per-service repository variables.
@@ -24,6 +50,9 @@
 
 - ✅ No long-lived Azure credential material stored in GitHub.
 - ✅ Per-fork identity limits impact if one repository is compromised.
+- ✅ The shared negative-test identity authenticates as a real caller while
+  remaining authorization-empty, so a 403 tests entitlements rather than an
+  invalid-token 401 path.
 - ✅ Credential and repository setup responsibilities are explicit and automatable.
 - ⚠️ Setup is operationally heavy without automation, so `spi onboard` + `init.yml` coordination is required.
 - ⚠️ Subject-claim mismatches (`refs/heads`, `pull_request`, `refs/tags`) cause authentication failures that are tedious to debug — the `oidc-smoke-test.yml` operator tool exists to validate each subject in isolation.
@@ -31,7 +60,10 @@
 ## Alternatives Considered
 
 - **Keep static `AZURE_CREDENTIALS` secrets** — rejected: long-lived secrets and a larger compromise surface.
-- **One shared identity for all service forks** — rejected: poor blast-radius isolation and weaker per-service boundary control.
+- **One privileged shared identity for all service forks** — rejected: poor
+  blast-radius isolation and weaker per-service boundary control. The shared
+  no-data-access identity is a narrow exception because it receives neither
+  deployment RBAC nor entitlements.
 
 ---
 

--- a/doc/src/adr/038-defer-extra-file-dockerfile-support.md
+++ b/doc/src/adr/038-defer-extra-file-dockerfile-support.md
@@ -1,0 +1,58 @@
+# ADR-038: Defer Extra-File Dockerfile Support for Core Service Onboarding
+
+## Context
+
+- ADR-037 established that the engineering system owns a single canonical service Dockerfile at `build/Dockerfile`, synced into service forks. Service forks do not supply their own CI Dockerfile.
+- The immediate SPI onboarding target is the 10 core service set used by the shared SPI Stack deploy loop: `partition`, `entitlements`, `legal`, `schema`, `file`, `storage`, `indexer`, `indexer-queue`, `search`, and `workflow`.
+- Official Azure SPI currently has only one service fork, `Azure/osdu-spi-partition`. SPI Stack already deploys the 10 core services plus three reference services, `crs-catalog`, `crs-conversion`, and `unit`, from community images through `osdu-image-lock`.
+- ADME's shared `oep-deployment-resources` build system has an alternate `DockerfileForExtraFiles` with an `OPTIONAL_FILES` build argument. That mechanism copies extra runtime files into the image with `COPY ${OPTIONAL_FILES} ${OPTIONAL_FILES}`.
+- ADME Partition and Entitlements do not use `OPTIONAL_FILES`. ADME usage was found only in the reference services:
+  - `OSDU-Crs-Catalog-Service`: `data/crs_catalog_v2.json`
+  - `OSDU-Crs-Conversion-Service`: `apachesis_setup`
+  - `OSDU-Unit-Service`: `data/unit_catalog_v2.json`
+- A raw `OPTIONAL_FILES` passthrough has a sharp edge: the ADME Dockerfile warns that an empty value can copy the entire Docker context. SPI's GitHub Actions path should not add that footgun without a concrete service requirement and path validation.
+
+## Decision
+
+Do not change the SPI canonical Dockerfile or `docker-build` action for the 10 core service onboarding wave.
+
+Do not add ADME-style raw `OPTIONAL_FILES` support now. The current `build/Dockerfile` plus `JAR_FILE` resolution remains sufficient for the 10 core services.
+
+If SPI later onboards reference services that need extra runtime files, introduce a separate, explicit, validated mechanism such as `SERVICE_EXTRA_FILES`, rather than a raw Docker build-arg passthrough. That future mechanism must validate that paths are relative, non-empty, present in the build context, and cannot use parent traversal or absolute paths.
+
+## Rationale
+
+- The current onboarding scope does not require extra files. Partition and Entitlements were checked directly, and neither ADME service uses `OPTIONAL_FILES`.
+- The ADME services that need extra files map to SPI Stack's reference-service set, not Daniel's immediate 10 core service set.
+- Keeping the Dockerfile unchanged avoids delaying core service onboarding for a capability that is not required by the core services.
+- Deferring extra-file support preserves the security and simplicity of the current Docker build contract: the build job produces a JAR, and the image build copies only that JAR plus centrally managed runtime files.
+- A future reference-service implementation can be designed with safe input validation instead of inheriting ADME's raw `OPTIONAL_FILES` behavior.
+
+## Consequences
+
+### Positive
+
+- The 10 core services can onboard with the existing canonical Dockerfile.
+- No extra per-service Dockerfile override or build argument is required for core services.
+- The Docker build contract stays small and auditable.
+- Future reference-service work can add extra-file support deliberately, with validation and tests.
+
+### Negative
+
+- `crs-catalog`, `crs-conversion`, and `unit` cannot yet be built by SPI if their runtime image requires the same extra files ADME bakes into those images.
+- A later reference-service onboarding wave will need a small design and implementation step before those services can use SPI-built images.
+
+### Neutral
+
+- SPI Stack can continue deploying reference services from community images through `osdu-image-lock` until SPI-built images for reference services are explicitly in scope.
+- ADME's `DockerfileForExtraFiles` remains useful evidence for future reference-service support, but it is not copied into SPI as-is.
+
+## Alternatives Considered
+
+- **Add raw `OPTIONAL_FILES` support now**: rejected because it is not needed for the 10 core services and can accidentally copy too much of the Docker context if empty or misconfigured.
+- **Copy ADME `DockerfileForExtraFiles` into SPI**: rejected because SPI should keep one canonical Dockerfile and avoid ADME-specific production pipeline assumptions.
+- **Service-owned Dockerfiles for services needing extras**: rejected for now because ADR-037 intentionally centralizes Dockerfile ownership to avoid per-fork drift. If reference services need extras, the centralized action/Dockerfile should support them safely.
+
+---
+
+[← ADR-037](037-engineering-system-owns-service-dockerfile.md) | :material-arrow-up: [Catalog](index.md)

--- a/doc/src/adr/index.md
+++ b/doc/src/adr/index.md
@@ -89,6 +89,7 @@ Decisions for the container-image build, cluster deploy, and integration-test pi
 | [035](035-azure-only-maven-profile.md) | **Azure-Only Maven Profile Restriction** | :material-minus: Medium |
 | [036](036-workflow-trust-boundaries.md) | **Workflow Trust Boundaries for CI/CD** | :material-trending-up: High |
 | [037](037-engineering-system-owns-service-dockerfile.md) | **Engineering System Owns the Canonical Service Dockerfile** | :material-trending-up: High |
+| [038](038-defer-extra-file-dockerfile-support.md) | **Defer Extra-File Dockerfile Support for Core Service Onboarding** | :material-minus: Medium |
 
 ### :material-package-variant: Release Management
 

--- a/doc/src/adr/index.md
+++ b/doc/src/adr/index.md
@@ -83,7 +83,9 @@ Decisions for the container-image build, cluster deploy, and integration-test pi
 
 | ADR | Decision | Impact |
 |-----|----------|--------|
+| [032](032-cicd-deploy-loop-via-suspended-flux.md) | **CI/CD Deploy Loop via Suspended Flux** | :material-trending-up: High |
 | [033](033-ghcr-as-service-image-registry.md) | **GHCR as Service Image Registry** | :material-minus: Medium |
+| [034](034-federated-identity-actions-to-azure.md) | **Federated Identity for Actions to Azure** | :material-trending-up: High |
 | [035](035-azure-only-maven-profile.md) | **Azure-Only Maven Profile Restriction** | :material-minus: Medium |
 | [036](036-workflow-trust-boundaries.md) | **Workflow Trust Boundaries for CI/CD** | :material-trending-up: High |
 | [037](037-engineering-system-owns-service-dockerfile.md) | **Engineering System Owns the Canonical Service Dockerfile** | :material-trending-up: High |

--- a/doc/src/adr/list.md
+++ b/doc/src/adr/list.md
@@ -221,6 +221,7 @@ These Architecture Decision Records document the key design choices made in the 
 **Federated Identity for Actions to Azure (ADR-034)**
 - One User-Assigned Managed Identity per service fork; GitHub Actions auth via OIDC `azure/login` (no static `AZURE_CREDENTIALS`)
 - Handoff contract is three repo secrets (`AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`); `AZURE_CLIENT_ID` is also a variable for `if:`/diagnostics
+- Selected negative-auth test profiles use one shared role-free, entitlement-free UAMI; other services skip the second token exchange
 - `oidc-smoke-test.yml` validates each federated-credential subject in isolation
 
 **Azure-Only Maven Profile Restriction (ADR-035)**

--- a/doc/src/adr/list.md
+++ b/doc/src/adr/list.md
@@ -45,6 +45,7 @@ Architecture Decision Records for Fork Management Template
 | 035 | Azure-Only Maven Profile Restriction       | [ADR-035](035-azure-only-maven-profile.md) |
 | 036 | Workflow Trust Boundaries for CI/CD        | [ADR-036](036-workflow-trust-boundaries.md) |
 | 037 | Engineering System Owns the Canonical Service Dockerfile | [ADR-037](037-engineering-system-owns-service-dockerfile.md) |
+| 038 | Defer Extra-File Dockerfile Support for Core Service Onboarding | [ADR-038](038-defer-extra-file-dockerfile-support.md) |
 
 ## Overview
 
@@ -237,3 +238,7 @@ These Architecture Decision Records document the key design choices made in the 
 - Mirrors the OSDU community `service-base-image/java/Dockerfile`: `COPY ${JAR_FILE} /app.jar` (no Maven in the image build); the JAR is the one our `java-build` job compiled from source, never a prebuilt artifact from OSDU's Maven registry
 - `JAR_FILE` defaults to `provider/<SERVICE_NAME>-azure/target/*-spring-boot.jar` (override via the `SERVICE_TARGET_JAR` repository variable); `BASE_IMAGE` is an `ARG` defaulting to OSDU `alpine-zulu17` so a later registry pivot is a one-line swap
 
+**Defer Extra-File Dockerfile Support for Core Service Onboarding (ADR-038)**
+- No Dockerfile or `docker-build` action change is required for the immediate 10 core service onboarding wave
+- ADME `OPTIONAL_FILES` usage was found only in reference services (`crs-catalog`, `crs-conversion`, `unit`), not Partition, Entitlements, or the 10 core service set
+- Extra-file image support should be deferred until reference-service onboarding and implemented with validated paths, not a raw Docker build-arg passthrough

--- a/doc/src/adr/list.md
+++ b/doc/src/adr/list.md
@@ -39,7 +39,9 @@ Architecture Decision Records for Fork Management Template
 | 029 | GitHub App Authentication Strategy         | [ADR-029](029-github-app-authentication-strategy.md) |
 | 030 | CodeQL Summary Job Pattern                 | [ADR-030](030-codeql-summary-job-pattern.md) |
 | 031 | Template Sync Duplicate Prevention Pattern | [ADR-031](031-template-sync-duplicate-prevention.md) |
+| 032 | CI/CD Deploy Loop via Suspended Flux       | [ADR-032](032-cicd-deploy-loop-via-suspended-flux.md) |
 | 033 | GHCR as Service Image Registry             | [ADR-033](033-ghcr-as-service-image-registry.md) |
+| 034 | Federated Identity for Actions to Azure    | [ADR-034](034-federated-identity-actions-to-azure.md) |
 | 035 | Azure-Only Maven Profile Restriction       | [ADR-035](035-azure-only-maven-profile.md) |
 | 036 | Workflow Trust Boundaries for CI/CD        | [ADR-036](036-workflow-trust-boundaries.md) |
 | 037 | Engineering System Owns the Canonical Service Dockerfile | [ADR-037](037-engineering-system-owns-service-dockerfile.md) |
@@ -205,10 +207,20 @@ These Architecture Decision Records document the key design choices made in the 
 - Branch reuse with force-push when template advances
 - Eliminates daily accumulation of open template-sync PRs
 
+**CI/CD Deploy Loop via Suspended Flux (ADR-032)**
+- Shared `osdu-spi-stack` cluster runs with all Flux Kustomizations permanently suspended (CI steady state)
+- Per-PR deploy jobs `kubectl set image` by immutable digest; a pre-flight asserts Flux is still suspended
+- Flux is resumed only during a planned baseline refresh; `K8S_DEPLOYMENT_NAME`/`K8S_CONTAINER_NAME` insulate CI from chart naming
+
 **GHCR as Service Image Registry (ADR-033)**
 - Public GHCR for SPI service CI/test artifacts consumed by the `osdu-spi-stack` AKS cluster
 - Push via `GITHUB_TOKEN`, pull anonymously from AKS — no `imagePullSecret`
 - MCR migration deferred; ACR/MCR swap is localized to the visibility helper, private-GHCR fallback is broader-touch
+
+**Federated Identity for Actions to Azure (ADR-034)**
+- One User-Assigned Managed Identity per service fork; GitHub Actions auth via OIDC `azure/login` (no static `AZURE_CREDENTIALS`)
+- Handoff contract is three repo secrets (`AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`); `AZURE_CLIENT_ID` is also a variable for `if:`/diagnostics
+- `oidc-smoke-test.yml` validates each federated-credential subject in isolation
 
 **Azure-Only Maven Profile Restriction (ADR-035)**
 - CI builds the Azure profile set with a hardcoded default of `core,azure` (correct for 9/10 forks); `core` is `activeByDefault`, so a bare `-P azure` would drop it

--- a/doc/src/workflows/build.md
+++ b/doc/src/workflows/build.md
@@ -35,7 +35,9 @@ The workflow produces clear outcomes to help you understand the state of your ch
 
 ### Build Features
 - **Maven dependency caching** - Speeds up builds by caching `.m2/repository`
-- **JaCoCo coverage reporting** - Generates detailed test coverage reports using JaCoCo plugin
+- **JaCoCo coverage reporting** - Generates downloadable reports plus a CSV-derived
+  step-summary table with per-module and aggregate line, branch, instruction, and
+  method coverage
 - **Community repository access** - Authenticates with GitLab Maven repositories for OSDU dependencies
 - **Artifact storage** - Saves test reports and coverage data for 30 days
 
@@ -152,6 +154,9 @@ open target/site/jacoco/index.html
 ### Artifact Handling
 - **Test reports** - Stored for 30 days in GitHub Actions
 - **Coverage reports** - Available as downloadable artifacts
+- **Integration-test summaries** - Report JUnit totals, failures/errors/skips,
+  test duration, retry attempts, deployed digest, no-data profile state, and the
+  downloadable JUnit artifact
 - **Build logs** - Accessible via Actions tab for debugging
 
 ## Related

--- a/tests/test_workflow_summaries.py
+++ b/tests/test_workflow_summaries.py
@@ -174,6 +174,18 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("if: github.event.repository.is_template == true", workflow)
         self.assertNotIn("github.repository == 'azure/osdu-spi'", workflow)
 
+    def test_java_build_provides_repository_local_sis_data(self):
+        action = (
+            ROOT / ".github" / "actions" / "java-build" / "action.yml"
+        ).read_text(encoding="utf-8")
+        workflow = (
+            ROOT / ".github" / "template-workflows" / "build.yml"
+        ).read_text(encoding="utf-8")
+        sis_data = "SIS_DATA: ${{ github.workspace }}/apachesis_setup/SIS_DATA"
+
+        self.assertIn(sis_data, action)
+        self.assertIn(sis_data, workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workflow_summaries.py
+++ b/tests/test_workflow_summaries.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {relative_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+coverage = _load_module(
+    "render_coverage_summary",
+    ".github/actions/java-build/render_coverage_summary.py",
+)
+junit = _load_module(
+    "summarize_junit",
+    ".github/actions/integration-test/summarize_junit.py",
+)
+
+
+class CoverageSummaryTests(unittest.TestCase):
+    def test_renders_module_and_total_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "provider" / "demo" / "target" / "site" / "jacoco"
+            report.mkdir(parents=True)
+            with (report / "jacoco.csv").open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.writer(stream)
+                writer.writerow(
+                    [
+                        "GROUP",
+                        "PACKAGE",
+                        "CLASS",
+                        "INSTRUCTION_MISSED",
+                        "INSTRUCTION_COVERED",
+                        "BRANCH_MISSED",
+                        "BRANCH_COVERED",
+                        "LINE_MISSED",
+                        "LINE_COVERED",
+                        "COMPLEXITY_MISSED",
+                        "COMPLEXITY_COVERED",
+                        "METHOD_MISSED",
+                        "METHOD_COVERED",
+                    ]
+                )
+                writer.writerow(["g", "p", "C", 20, 80, 2, 8, 5, 15, 1, 3, 2, 6])
+
+            summary = coverage.render_summary(root)
+
+            self.assertIn("`provider/demo`", summary)
+            self.assertIn("75.0% (15/20)", summary)
+            self.assertIn("80.0% (8/10)", summary)
+            self.assertIn("**Total**", summary)
+            self.assertIn("Generated from 1 JaCoCo CSV report", summary)
+
+    def test_reports_missing_coverage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertIn(
+                "No JaCoCo CSV reports were generated",
+                coverage.render_summary(Path(directory)),
+            )
+
+
+class JunitSummaryTests(unittest.TestCase):
+    def test_aggregates_surefire_and_failsafe_reports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            surefire = root / "a" / "target" / "surefire-reports"
+            failsafe = root / "b" / "target" / "failsafe-reports"
+            surefire.mkdir(parents=True)
+            failsafe.mkdir(parents=True)
+            (surefire / "TEST-one.xml").write_text(
+                '<testsuite tests="3" failures="1" errors="0" skipped="1" time="2.5"/>',
+                encoding="utf-8",
+            )
+            (failsafe / "TEST-two.xml").write_text(
+                '<testsuites tests="2" failures="0" errors="1" time="1.25"/>',
+                encoding="utf-8",
+            )
+            (failsafe / "broken.xml").write_text("<testsuite", encoding="utf-8")
+
+            metrics = junit.collect_metrics(root)
+
+            self.assertEqual(5, metrics.tests)
+            self.assertEqual(1, metrics.failures)
+            self.assertEqual(1, metrics.errors)
+            self.assertEqual(1, metrics.skipped)
+            self.assertEqual(3.75, metrics.duration_seconds)
+            self.assertEqual(2, metrics.report_files)
+            self.assertEqual(1, metrics.parse_errors)
+
+    def test_formats_duration(self):
+        self.assertEqual("12.3s", junit.format_duration(12.3))
+        self.assertEqual("2m 5s", junit.format_duration(125))
+        self.assertEqual("1h 1m 1s", junit.format_duration(3661))
+
+    def test_uses_testsuites_aggregate_without_double_counting_children(self):
+        with tempfile.TemporaryDirectory() as directory:
+            report_dir = Path(directory) / "target" / "surefire-reports"
+            report_dir.mkdir(parents=True)
+            (report_dir / "TEST-aggregate.xml").write_text(
+                """
+                <testsuites tests="4" failures="1" errors="0" skipped="1" time="6">
+                  <testsuite tests="4" failures="1" errors="0" skipped="1" time="6"/>
+                </testsuites>
+                """,
+                encoding="utf-8",
+            )
+            (report_dir / "failsafe-summary.xml").write_text(
+                "<failsafe-summary result='254'/>",
+                encoding="utf-8",
+            )
+
+            metrics = junit.collect_metrics(Path(directory))
+
+            self.assertEqual(4, metrics.tests)
+            self.assertEqual(1, metrics.failures)
+            self.assertEqual(1, metrics.skipped)
+            self.assertEqual(1, metrics.report_files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_summaries.py
+++ b/tests/test_workflow_summaries.py
@@ -132,5 +132,48 @@ class JunitSummaryTests(unittest.TestCase):
             self.assertEqual(1, metrics.report_files)
 
 
+class WorkflowContractTests(unittest.TestCase):
+    def test_template_sync_uses_conventional_pull_request_titles(self):
+        workflow = (
+            ROOT / ".github" / "template-workflows" / "sync-template.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            'pr-title: "chore: sync template updates ${{ env.CURRENT_DATE }}"',
+            workflow,
+        )
+        self.assertIn(
+            '--title "chore: sync template updates $(date +%Y-%m-%d)"',
+            workflow,
+        )
+        self.assertNotIn('pr-title: "Sync template updates', workflow)
+        self.assertNotIn('--title "🔄 Sync template updates', workflow)
+
+    def test_feature_build_honors_service_maven_profile(self):
+        workflow = (
+            ROOT / ".github" / "template-workflows" / "build.yml"
+        ).read_text(encoding="utf-8")
+        dependabot_workflow = (
+            ROOT / ".github" / "template-workflows" / "dependabot-validation.yml"
+        ).read_text(encoding="utf-8")
+
+        profile_expression = "${{ vars.MAVEN_PROFILE || 'core,azure' }}"
+        self.assertIn(f"maven_profile: {profile_expression}", workflow)
+        self.assertIn(f"MAVEN_PROFILE: {profile_expression}", workflow)
+        self.assertIn(f"maven_profile: {profile_expression}", dependabot_workflow)
+        self.assertIn(
+            'MAVEN_CLI_OPTS="$MAVEN_CLI_OPTS -P $MAVEN_PROFILE"',
+            workflow,
+        )
+
+    def test_template_ci_runs_for_any_template_repository(self):
+        workflow = (ROOT / ".github" / "workflows" / "dev-ci.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("if: github.event.repository.is_template == true", workflow)
+        self.assertNotIn("github.repository == 'azure/osdu-spi'", workflow)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds the CI/CD deploy lane to the fork-management template: the workflows, composite actions and conventions that let a service fork build an image, deploy it to a running SPI Stack cluster, and run its acceptance suite against that deployment — without storing any long-lived credential.

Every service fork inherits this through template sync, so a single lane definition serves the whole fleet.

## What this adds

### Deploy and test on every pull request

`validate.yml` gains two jobs that run after the image is built and pushed:

- **Deploy to spi-stack** sets the target Deployment to the exact digest just built, by digest rather than tag, and waits for the rollout.
- **Integration Tests** runs the fork's acceptance suite against that deployment and publishes a JUnit summary.

Both are per-service concurrency-guarded so two runs for the same service queue rather than fight over the cluster, and the test job re-reads the live pod image before starting, so a run can never report a result for an image it did not deploy.

### Three reusable composite actions

| Action | Responsibility |
| --- | --- |
| `aks-deploy` | Azure OIDC login, kubeconfig, CI-mode pre-flight, deploy by digest, capture the previous digest for rollback |
| `integration-test` | Mint tokens, load test configuration, run Maven, summarize JUnit results |
| `cluster-health-check` | Report whether the target cluster is in a state a deploy can safely use |

Keeping these as actions rather than inline steps is what makes the lane fixable in one place for all thirteen services.

### Secret-less test authentication

The acceptance suites need an OSDU bearer token. Rather than storing one, the lane mints it at run time from the workflow's federated identity, following the ADME pattern, and exports it under the canonical name the OSDU suites already expect. Repositories that exercise negative-authorization paths can additionally opt into a second, deliberately unprivileged token.

No test credential is persisted in any repository.

### Operator break-glass

`restore-deployment.yml` rolls a service back to a previously deployed digest on demand. It is human-triggered only — there is no automatic rollback — and it reads its target service from the repository itself, so an operator cannot accidentally roll back a different fork's Deployment.

`oidc-smoke-test.yml` verifies federation, cluster reachability and namespace access independently of a code change, which makes onboarding problems diagnosable in isolation.

### Build and reporting improvements

Coverage and integration results are rendered into job summaries; Maven profile and provider scopes are aligned across the workflows so a build's scope matches what protected-main validation enforces.

## Decision records

- **ADR-032** — CI/CD deploy loop via suspended Flux
- **ADR-034** — Federated identity from Actions to Azure
- **ADR-038** — Deferral of extra-file Dockerfile support

## Validation

The lane has been exercised end to end against a live SPI Stack cluster, not just in isolation.

**Full pipeline, all green** — [`yuchen-osdu/storage` run 30301239194](https://github.com/yuchen-osdu/storage/actions/runs/30301239194):

```
🔨 Java Build                success
🐳 Docker Build (validate)   success
✅ Code Quality Checks       success
🐳 Docker Push               success
🚀 Deploy to spi-stack       success
🧪 Integration Tests         success
```

Also verified:

- **OIDC federation** — the smoke workflow passes against a freshly onboarded repository, confirming federated login, cluster credentials and namespace access.
- **Break-glass rollback** — `restore-deployment` was run against the live cluster and moved the service from the pull request's test image back to the previous digest, with the pod healthy afterwards.
- **Template propagation** — changes were delivered to a downstream service fork through the normal template-sync path and merged there, confirming the fleet distribution mechanism works for these files.

## Notes for reviewers

- Third-party actions are pinned to full commit SHAs.
- The credentialed jobs are excluded from `pull_request_target`, so fork pull requests cannot reach secrets.
- The deploy and test jobs are gated, so a repository that has not been onboarded is unaffected.